### PR TITLE
feat: enhance Open Graph metadata with article image

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,12 +1,13 @@
 ---
 import "../index.css";
 
-import { Image } from "astro:assets";
+import { Image, getImage  } from "astro:assets";
 import heroImage from "/src/assets/th3S4mur41_colors_ultrawide.png";
 import Socials from "../components/Socials.astro";
 
 interface Props {
 	title: string;
+	image?: string;
 	noHeader?: boolean;
 	canonical?: string;
 	noIndex?: boolean;
@@ -15,7 +16,7 @@ interface Props {
 	keywords?: string[];
 }
 
-const { title, description } = Astro.props;
+const { title, image, description } = Astro.props;
 const pageTitle = title ? `${title} | Th3S4mur41.me` : "Th3S4mur41.me";
 const header = title ? title : "Th3S3mur41.me";
 const currentYear = new Date().getFullYear();
@@ -39,6 +40,23 @@ const defaultKeywords = [
 	"ux",
 ];
 const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...defaultKeywords]));
+
+
+// Retrieve metadata for the hero image
+const ogImageMetadata = image 
+  ? await getImage({
+      src: (await import(image)).default,
+    })
+  : {
+      src: "/icons/android-icon-512x512.png",
+      attributes: {
+        width: 512,
+        height: 512,
+      },
+    };
+const ogImageUrl = ogImageMetadata.src;
+const ogImageWidth = ogImageMetadata.attributes.width;
+const ogImageHeight = ogImageMetadata.attributes.height;
 ---
 
 <!doctype html>
@@ -90,9 +108,9 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 		<meta property="og:title" content={pageTitle} />
 		<meta property="og:description" content={desc} />
 		<meta property="og:url" content={Astro.url.href} />
-		<meta property="og:image" content="https://th3s4mur41.me/icons/android-icon-512x512.png" />
-		<meta property="og:image:width" content="512" />
-		<meta property="og:image:height" content="512" />
+		<meta property="og:image" content={ogImageUrl} />
+		<meta property="og:image:width" content={ogImageWidth} />
+		<meta property="og:image:height" content={ogImageHeight} />
 		<meta property="og:type" content="website" />
 		<!-- <meta property="article:published_time" content="{currentLocalISODate}" />
 		<meta property="article:modified_time" content="{currentLocalISODate}" /> -->
@@ -106,7 +124,7 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 	{!Astro.props.noHeader && (
 		<header>
 			<h1>{header}</h1>
-			<Image src={heroImage} alt='' />
+			<Image src={image || heroImage} alt="" />
 		</header>
 	)}
 	<nav aria-label="main">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,13 +1,13 @@
 ---
 import "../index.css";
 
-import { Image, getImage  } from "astro:assets";
+import { Image } from "astro:assets";
 import heroImage from "/src/assets/th3S4mur41_colors_ultrawide.png";
 import Socials from "../components/Socials.astro";
 
 interface Props {
 	title: string;
-	image?: string;
+	image?: any;
 	noHeader?: boolean;
 	canonical?: string;
 	noIndex?: boolean;
@@ -44,12 +44,13 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 
 // Retrieve metadata for the hero image
 const ogImageMetadata = image 
-  ? await getImage({
-      src: (await import(image /* @vite-ignore */)).default,
-			width: 1200,
-			height: 630,
-			format: "jpg",
-    })
+  ? {
+      src: image.src,
+			attributes: {
+        width: image.attributes.width,
+        height: image.attributes.height,
+      },
+    }
   : {
       src: "/icons/android-icon-512x512.png",
       attributes: {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -45,7 +45,10 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 // Retrieve metadata for the hero image
 const ogImageMetadata = image 
   ? await getImage({
-      src: (await import(image)).default,
+      src: (await import(image /* @vite-ignore */)).default,
+			width: 1200,
+			height: 630,
+			format: "jpg",
     })
   : {
       src: "/icons/android-icon-512x512.png",
@@ -54,9 +57,7 @@ const ogImageMetadata = image
         height: 512,
       },
     };
-const ogImageUrl = ogImageMetadata.src;
-const ogImageWidth = ogImageMetadata.attributes.width;
-const ogImageHeight = ogImageMetadata.attributes.height;
+
 ---
 
 <!doctype html>
@@ -108,9 +109,9 @@ const ogImageHeight = ogImageMetadata.attributes.height;
 		<meta property="og:title" content={pageTitle} />
 		<meta property="og:description" content={desc} />
 		<meta property="og:url" content={Astro.url.href} />
-		<meta property="og:image" content={ogImageUrl} />
-		<meta property="og:image:width" content={ogImageWidth} />
-		<meta property="og:image:height" content={ogImageHeight} />
+		<meta property="og:image" content={ogImageMetadata.src} />
+		<meta property="og:image:width" content={ogImageMetadata.attributes.width} />
+		<meta property="og:image:height" content={ogImageMetadata.attributes.height} />
 		<meta property="og:type" content="website" />
 		<!-- <meta property="article:published_time" content="{currentLocalISODate}" />
 		<meta property="article:modified_time" content="{currentLocalISODate}" /> -->
@@ -124,7 +125,7 @@ const ogImageHeight = ogImageMetadata.attributes.height;
 	{!Astro.props.noHeader && (
 		<header>
 			<h1>{header}</h1>
-			<Image src={image || heroImage} alt="" />
+			<Image src={heroImage} alt="" />
 		</header>
 	)}
 	<nav aria-label="main">

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -14,10 +14,16 @@ export async function getStaticPaths() {
 }
 
 const { Content } = await render(article);
+const imgPath = article.data.image ? `/src/content/blog/${slug}/${article.data.image}` : undefined;
 ---
 
 <Layout 
-	title={article.data.title} description={article.data.description} noIndex={!article.data.published} canonical={article.data.canonical ?? undefined} noHeader>
+	title={article.data.title} 
+	image={imgPath}
+	description={article.data.description} 
+	noIndex={!article.data.published} 
+	canonical={article.data.canonical ?? undefined} 
+	noHeader>
   <article>
     {/** Render markdown as HTML using Astro's set:html directive */}
 	  <Content />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, getEntry, render } from "astro:content";
+import { getImage  } from "astro:assets";
 import Layout from "../../layouts/Layout.astro";
 
 const { slug } = Astro.params;
@@ -14,12 +15,22 @@ export async function getStaticPaths() {
 }
 
 const { Content } = await render(article);
-const imgPath = article.data.image ? `/src/content/blog/${slug}/${article.data.image}` : undefined;
+
+const blogImages = import.meta.glob("/src/content/blog/**/*.{jpg,png,webp}", { eager: true });
+
+const imagePath = article.data.image ? `/src/content/blog/${slug}/${article.data.image}` : undefined;
+const img = imagePath ? await getImage({
+      src: blogImages[imagePath]?.default ,
+			width: 1200,
+			height: 630,
+			format: "jpg",
+    }) : null;
 ---
+
 
 <Layout 
 	title={article.data.title} 
-	image={imgPath}
+	image={img}
 	description={article.data.description} 
 	noIndex={!article.data.published} 
 	canonical={article.data.canonical ?? undefined} 


### PR DESCRIPTION
This pull request introduces support for dynamic Open Graph (OG) image metadata for blog posts. The main change allows each blog post to specify its own hero image, which is then processed and injected into the OG meta tags for better social sharing previews. The implementation involves updates to both the blog post rendering logic and the main layout to handle image metadata.

**Dynamic OG image support for blog posts:**

* Blog post pages now load and process a hero image using `getImage` from `astro:assets`, based on the post's metadata. This image is passed to the layout for use in OG tags. ([src/pages/blog/[slug].astroR3](diffhunk://#diff-c8e7929728443eef3921004f841ccbf1f6000b152eba780e1eabaa7b150f8cf8R3), [src/pages/blog/[slug].astroR18-R37](diffhunk://#diff-c8e7929728443eef3921004f841ccbf1f6000b152eba780e1eabaa7b150f8cf8R18-R37))

**Layout and metadata updates:**

* The `Layout.astro` component's `Props` interface now supports an optional `image` property, and the logic for OG image meta tags uses the provided image's metadata or falls back to a default icon if none is specified. [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R10) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L18-R19) [[3]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R43-R61) [[4]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L93-R115)

**Minor fixes:**

* Minor formatting update to the `Image` component's `alt` attribute in the header for consistency.