### PR TITLE
feat(blog): update blog page to include reading time calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
 				"postcss-nesting": "^13.0.2",
 				"postcss-preset-env": "^10.4.0",
 				"prettier": "^3.6.2",
+				"reading-time": "^1.5.0",
 				"typescript": "^5.9.2",
 				"vite": "^7.1.7",
 				"vite-plugin-handlebars": "^2.0.0"
@@ -23115,6 +23116,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
+		},
+		"node_modules/reading-time": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+			"integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/recma-build-jsx": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"postcss-nesting": "^13.0.2",
 		"postcss-preset-env": "^10.4.0",
 		"prettier": "^3.6.2",
+		"reading-time": "^1.5.0",
 		"typescript": "^5.9.2",
 		"vite": "^7.1.7",
 		"vite-plugin-handlebars": "^2.0.0"

--- a/src/content.config.js
+++ b/src/content.config.js
@@ -1,10 +1,7 @@
-// 1. Import utilities from `astro:content`
 import { defineCollection, z } from "astro:content";
-
-// 2. Import loader(s)
 import { glob } from "astro/loaders";
 
-// 3. Define shared schema for contact cards and employee profiles
+// Define shared schema for contact cards and employee profiles
 const blogSchema = z.object({
 	title: z.string(),
 	date: z.date(),
@@ -17,11 +14,11 @@ const blogSchema = z.object({
 	canonical: z.string().optional(),
 });
 
-// 4. Define your collection(s)
+// Define your collection(s)
 const blog = defineCollection({
 	loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/blog" }),
 	schema: blogSchema,
 });
 
-// 5. Export a single `collections` object to register your collection(s)
+// Export a single `collections` object to register your collection(s)
 export const collections = { blog };

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getImage } from "astro:assets";
 import { getCollection, getEntry, render } from "astro:content";
+import readingTime from "reading-time";
 import Layout from "../../layouts/Layout.astro";
 
 const { slug } = Astro.params;
@@ -15,18 +16,26 @@ export async function getStaticPaths() {
 }
 
 const { Content } = await render(article);
+const minutesRead = Math.max(1, Math.ceil(readingTime(article.body).minutes));
 
-const blogImages = import.meta.glob("/src/content/blog/**/*.{jpg,png,webp}", { eager: true });
+const blogImages = import.meta.glob<Record<string, { default: ImageMetadata }>>(
+	"/src/content/blog/**/*.{jpg,png,webp}",
+	{ eager: true },
+);
 
 const imagePath = article.data.image ? `/src/content/blog/${slug}/${article.data.image}` : undefined;
-const img = imagePath
-	? await getImage({
-			src: blogImages[imagePath]?.default,
+let img: Awaited<ReturnType<typeof getImage>> | undefined;
+if (imagePath) {
+	const mod = blogImages[imagePath] as unknown as { default?: ImageMetadata } | undefined;
+	if (mod?.default) {
+		img = await getImage({
+			src: mod.default,
 			width: 1200,
 			height: 630,
 			format: "jpg",
-		})
-	: null;
+		});
+	}
+}
 ---
 
 


### PR DESCRIPTION
This pull request introduces a new feature to display estimated reading time for blog articles and improves type safety and code clarity in blog image handling. The most important changes are grouped below.

**New Feature: Reading Time**

* Added the `reading-time` package as a dependency in `package.json` and integrated it into the blog post page to calculate and display estimated reading time (`minutesRead`). ([package.jsonR59](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R59), [src/pages/blog/[slug].astroR4](diffhunk://#diff-c8e7929728443eef3921004f841ccbf1f6000b152eba780e1eabaa7b150f8cf8R4), [src/pages/blog/[slug].astroR19-R38](diffhunk://#diff-c8e7929728443eef3921004f841ccbf1f6000b152eba780e1eabaa7b150f8cf8R19-R38))

**Code Quality and Type Safety Improvements**

* Enhanced type safety for blog image imports in `[slug].astro` by specifying the type for `blogImages` and refactoring the image loading logic to handle missing images more gracefully. ([src/pages/blog/[slug].astroR19-R38](diffhunk://#diff-c8e7929728443eef3921004f841ccbf1f6000b152eba780e1eabaa7b150f8cf8R19-R38))
* Cleaned up comments and improved clarity in `content.config.js` by removing numbered steps and using more descriptive comments. [[1]](diffhunk://#diff-f78604c567e52b762610ec9a58e5538504a7c0956e22ed8c0c70cbd37e978aceL1-R4) [[2]](diffhunk://#diff-f78604c567e52b762610ec9a58e5538504a7c0956e22ed8c0c70cbd37e978aceL20-R23)