### PR TITLE
fix: simplify browser support list by removing specific version entries

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -4,17 +4,6 @@
 
 > .5% in alt-EU and not last 2 versions and not dead
 
-# Desktop
-
-last 2 Chrome versions
-last 2 Edge versions
-last 2 Firefox versions
+baseline widely available
 Firefox ESR
-last 2 Opera versions
-last 2 Safari major versions
-
-# Mobile
-
-last 2 ChromeAndroid versions
-last 2 FirefoxAndroid versions
-last 2 iOS versions
+not dead


### PR DESCRIPTION
Basing [browserslist](https://browsersl.ist/) on the newly available baseline should improve compatibility