### PR TITLE
fix: add rehype plugin for unique view-transition names and update templates for smooth transitions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,14 @@
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import { defineConfig } from "astro/config";
+import { rehypeViewTransitionNames } from "./src/plugins/rehype-view-transition-names.js";
 
 // https://astro.build/config
 export default defineConfig({
 	site: "https://th3s4mur41.me",
 	markdown: {
 		syntaxHighlight: "prism",
+		rehypePlugins: [rehypeViewTransitionNames],
 	},
 	integrations: [
 		sitemap({
@@ -15,7 +17,9 @@ export default defineConfig({
 			// Example draft path: https://th3s4mur41.me/blog/_draft-my-new-post/
 			filter: (pageUrl) => !pageUrl.includes("/blog/_draft-"),
 		}),
-		mdx(),
+		mdx({
+			rehypePlugins: [rehypeViewTransitionNames],
+		}),
 	],
 	devToolbar: {
 		enabled: false, // Disable the Astro toolbar

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -30,11 +30,11 @@ void [combined, blogImages, talksImages, Image, Layout];
 	return (
 		<a href={href} aria-labelledby={`article-header-${section}-${entry.id}`} aria-describedby={`article-description-${section}-${entry.id}`}>
 			<article>
-				<h2 id={`article-header-${section}-${entry.id}`}>
+				<h2 id={`article-header-${section}-${entry.id}`} style={`view-transition-name: article-title-${entry.id};`}>
 					{entry.data.title} 
 				</h2>
 				<span class="type">{entry.data.type}</span>
-				{image && <Image src={image} alt={entry.data.imageAlt || entry.data.title} loading="lazy" />}
+				{image && <Image src={image} alt={entry.data.imageAlt || entry.data.title} loading="lazy" style={`view-transition-name: article-hero-image-${entry.id};`} />}
 				<p id={`article-description-${section}-${entry.id}`}>{entry.data.description}</p>
 				<time datetime={entry.data.date}>{date.toLocaleDateString('en-gb', { year: 'numeric', month: 'short', day: 'numeric' })}</time>
 			</article>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,8 +55,8 @@ const talkImage = talkImagePath ? talkImages[talkImagePath]?.default : null;
 	{lastPublishedPost && (
 		<a href={`/blog/${lastPublishedPost.id}/`} aria-labelledby={`article-header-${lastPublishedPost.id}`} aria-describedby={`article-description-${lastPublishedPost.id}`}>
 			<article>
-				<h3 id={`article-header-${lastPublishedPost.id}`}>{lastPublishedPost.data.title}</h3>
-				{image && <Image src={image} alt="" />}
+				<h3 id={`article-header-${lastPublishedPost.id}`} style={`view-transition-name: article-title-${lastPublishedPost.id};`}>{lastPublishedPost.data.title}</h3>
+				{image && <Image src={image} alt="" style={`view-transition-name: article-hero-image-${lastPublishedPost.id};`} />}
 				<p id={`article-description-${lastPublishedPost.id}`}>{lastPublishedPost.data.description}</p>
 				<time datetime={lastPublishedPost.data.date}>
 					{new Date(lastPublishedPost.data.date).toLocaleDateString(undefined, dateOptions)}
@@ -69,8 +69,8 @@ const talkImage = talkImagePath ? talkImages[talkImagePath]?.default : null;
 		<h2>Latest talk</h2>
 		<a href={`/talks/${lastPublishedTalk.id}/`} aria-labelledby={`talk-header-${lastPublishedTalk.id}`}>
 			<article aria-labelledby={`talk-header-${lastPublishedTalk.id}`} data-type={lastPublishedTalk.data.type}>
-				<h3 id={`talk-header-${lastPublishedTalk.id}`}>{lastPublishedTalk.data.title}</h3>
-				{talkImage && <Image src={talkImage} alt="" />}
+				<h3 id={`talk-header-${lastPublishedTalk.id}`} style={`view-transition-name: article-title-${lastPublishedTalk.id};`}>{lastPublishedTalk.data.title}</h3>
+				{talkImage && <Image src={talkImage} alt="" style={`view-transition-name: article-hero-image-${lastPublishedTalk.id};`} />}
 				<p>{lastPublishedTalk.data.description}</p>
 				<time datetime={lastPublishedTalk.data.date}>
 					{new Date(lastPublishedTalk.data.date).toLocaleDateString(undefined, dateOptions)}

--- a/src/plugins/rehype-view-transition-names.js
+++ b/src/plugins/rehype-view-transition-names.js
@@ -1,0 +1,68 @@
+/**
+ * Rehype plugin to add unique view-transition-name attributes to article elements
+ * This allows for smooth view transitions between listing pages and individual articles
+ *
+ * The articleId is extracted from the file path during processing
+ */
+export function rehypeViewTransitionNames() {
+	return function transformer(tree, file) {
+		// Extract articleId from file path
+		// file.path will be something like "/src/content/blog/my-article/index.mdx"
+		const pathParts = file.path?.split("/") || [];
+		const contentIndex = pathParts.indexOf("content");
+
+		if (contentIndex === -1 || contentIndex + 2 >= pathParts.length) {
+			// Not a content file or can't determine articleId
+			return tree;
+		}
+
+		// The articleId is the folder name (e.g., "my-article" from "content/blog/my-article/index.mdx")
+		const articleId = pathParts[contentIndex + 2];
+
+		if (!articleId) {
+			return tree;
+		}
+
+		// Find the first h1 (article title) and first hero image
+		let foundH1 = false;
+		let foundHeroImage = false;
+
+		function visit(node) {
+			// Add view-transition-name to the first h1
+			if (!foundH1 && node.type === "element" && node.tagName === "h1") {
+				foundH1 = true;
+				node.properties = node.properties || {};
+				node.properties.style = node.properties.style
+					? `${node.properties.style}; view-transition-name: article-title-${articleId};`
+					: `view-transition-name: article-title-${articleId};`;
+			}
+
+			// Find hero image (first img in p following h1)
+			if (foundH1 && !foundHeroImage && node.type === "element" && node.tagName === "p") {
+				// Check if this paragraph contains an img
+				const hasImg = node.children?.some((child) => child.type === "element" && child.tagName === "img");
+
+				if (hasImg) {
+					foundHeroImage = true;
+					// Find the img element and add view-transition-name
+					node.children.forEach((child) => {
+						if (child.type === "element" && child.tagName === "img") {
+							child.properties = child.properties || {};
+							child.properties.style = child.properties.style
+								? `${child.properties.style}; view-transition-name: article-hero-image-${articleId};`
+								: `view-transition-name: article-hero-image-${articleId};`;
+						}
+					});
+				}
+			}
+
+			// Recursively visit children
+			if (node.children) {
+				node.children.forEach(visit);
+			}
+		}
+
+		visit(tree);
+		return tree;
+	};
+}

--- a/src/styles/pages/blog.css
+++ b/src/styles/pages/blog.css
@@ -77,7 +77,8 @@ body:is([class^="blog-"], [class^="talks-"]) {
 			grid-column: content;
 		}
 		& h1 {
-			view-transition-name: article-title;
+			/* TODO: replace through ident() when available - https://drafts.csswg.org/css-values-5/#funcdef-ident
+			  In the meantime, set view-transition-name inline in template */
 		}
 		/* Treat an image following the h1 as the hero image */
 		& h1 + p:has(img) {
@@ -88,7 +89,8 @@ body:is([class^="blog-"], [class^="talks-"]) {
 				inline-size: 100%;
 				block-size: auto;
 				object-fit: cover;
-				view-transition-name: article-hero-image;
+				/* TODO: replace through ident() when available - https://drafts.csswg.org/css-values-5/#funcdef-ident
+			  In the meantime, set view-transition-name inline in template */
 			}
 		}
 		& > footer {

--- a/src/styles/pages/home.css
+++ b/src/styles/pages/home.css
@@ -37,7 +37,8 @@ body.home {
 		& > h3 {
 			grid-area: title;
 			margin: 0;
-			view-transition-name: article-title;
+			/* TODO: replace through ident() when available - https://drafts.csswg.org/css-values-5/#funcdef-ident
+			  In the meantime, set view-transition-name inline in template */
 		}
 		& img {
 			grid-area: image;
@@ -46,7 +47,8 @@ body.home {
 			max-block-size: 100%;
 			object-fit: cover;
 			border-radius: 0.5rem;
-			view-transition-name: article-hero-image;
+			/* TODO: replace through ident() when available - https://drafts.csswg.org/css-values-5/#funcdef-ident
+			  In the meantime, set view-transition-name inline in template */
 		}
 		& p {
 			grid-area: teaser;


### PR DESCRIPTION
This is a temporary solution until ident() function becomes available https://drafts.csswg.org/css-values-5/#funcdef-ident

This pull request introduces support for smooth view transitions between listing pages and individual articles by adding unique `view-transition-name` attributes to article titles and hero images. The changes include a new Rehype plugin to automate this process for content files, updates to Astro configuration to enable the plugin for both Markdown and MDX, and template changes to set the transition names inline. Additionally, related CSS is updated to remove hardcoded transition names and add comments explaining the new approach.

**View Transition Support**

* Added a new Rehype plugin (`rehypeViewTransitionNames`) that automatically sets unique `view-transition-name` attributes on the first `<h1>` (article title) and hero image in content files, enabling smooth transitions between pages. (`src/plugins/rehype-view-transition-names.js`)
* Updated `astro.config.mjs` to use the new plugin for both Markdown and MDX content, ensuring transition names are applied during build. [[1]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR4-R11) [[2]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL18-R22)

**Template Updates**

* Modified blog and homepage templates to set `view-transition-name` inline for article titles and hero images, using the article/talk ID for uniqueness. (`src/pages/blog.astro`, `src/pages/index.astro`) [[1]](diffhunk://#diff-7968dd4f35b1d48d90e332e78caa762fe415e5d9fdc252bfdb4f80373f925e0bL33-R37) [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L58-R59) [[3]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L72-R73)

**CSS Adjustments**

* Removed hardcoded `view-transition-name` properties from blog and home page CSS, replacing them with comments referencing the new inline approach and future CSS improvements. (`src/styles/pages/blog.css`, `src/styles/pages/home.css`) [[1]](diffhunk://#diff-17d7e195862409c118b0901f43752531d91ed1241c198edcc431d422556b18a1L80-R81) [[2]](diffhunk://#diff-17d7e195862409c118b0901f43752531d91ed1241c198edcc431d422556b18a1L91-R93) [[3]](diffhunk://#diff-00ec2b2e93a7a7519384b2ad93afc9483a6d3bc9d2baa6d645a379ce17733846L40-R41) [[4]](diffhunk://#diff-00ec2b2e93a7a7519384b2ad93afc9483a6d3bc9d2baa6d645a379ce17733846L49-R51)