### PR TITLE
feat(prism): add language label display for code blocks

### DIFF
--- a/src/styles/prism.css
+++ b/src/styles/prism.css
@@ -2,6 +2,17 @@
  * Based on the prism-a11y-dark theme: https://github.com/PrismJS/prism-themes/blob/master/themes/prism-a11y-dark.css
  */
 
+pre[data-language]::before {
+	content: attr(data-language);
+	display: block;
+	padding-block-end: 0.5em;
+	border-block-end: 1px solid var(--color-subtle-bg);
+	margin-block-end: 1em;
+	font-size: 1.2em;
+	font-weight: 500;
+	text-transform: uppercase;
+}
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #f8f8f2;


### PR DESCRIPTION
This pull request adds a new visual enhancement to code blocks in the application. Specifically, it introduces a language label above code snippets, making it easier for users to identify the programming language of each code block.

**Styling improvements:**

* Added a CSS rule to display the programming language as a label above code blocks using the `pre[data-language]::before` selector in `src/styles/prism.css`. This label uses the `data-language` attribute, is styled for emphasis, and visually separates the label from the code with padding and a border.