### PR TITLE
fix: update alt text for accessibility image in contrast article

### DIFF
--- a/src/content/blog/a11y-tips/contrast/index.mdx
+++ b/src/content/blog/a11y-tips/contrast/index.mdx
@@ -31,7 +31,7 @@ import CodePen from '../../../../components/CodePen.astro';
 
 # Contrast: Beyond WCAG Compliance
 
-![The CSS logo in front of a skeleton UI template](../Practical_Accessibility_Tips_for_Developers.jpg)
+![Comic-style illustration of a bearded developer wearing a baseball cap and samurai-themed shirt, working on a laptop with a samurai sticker. To the side, accessibility icons and the hashtag #A11yTips promote practical accessibility tips for developers.](../Practical_Accessibility_Tips_for_Developers.jpg)
 
 Contrast is one of the easiest accessibility aspects to evaluate because it can be measured with algorithms. Whether through automated tools or semi‑automatic checks, developers can quickly verify if text and background combinations meet established standards. This makes contrast a practical starting point for improving accessibility - though, as we'll see, compliance alone doesn't always guarantee the best user experience.
 
@@ -57,6 +57,7 @@ Try the demo interactively:
 	height={500}
 	description="Interactive CodePen demo comparing contrast outcomes for WCAG vs APCA."
 />
+
 
 <section class="sidenote">
 


### PR DESCRIPTION
This pull request updates the blog post on contrast accessibility tips with an improved image description and a minor formatting tweak. The most significant change is a more descriptive and context-rich alt text for the main blog image, enhancing accessibility for screen reader users.

Accessibility improvements:

* Updated the alt text for the main blog image to provide a detailed and contextually relevant description, making the content more accessible to users relying on assistive technologies.

Formatting:

* Added a blank line before the sidenote section for improved readability in the markdown file.