### PR TITLE
fix: correct publisher ID in JSON-LD schema and update person description

### DIFF
--- a/src/components/BlogPostingSchema.astro
+++ b/src/components/BlogPostingSchema.astro
@@ -53,7 +53,7 @@ const blogPostingData = {
 		"@id": `${origin}/#person`,
 	},
 	publisher: {
-		"@id": `${origin}/#website`,
+		"@id": `${origin}/#person`,
 	},
 	isPartOf: {
 		"@id": `${origin}/#website`,

--- a/src/utils/schemaData.ts
+++ b/src/utils/schemaData.ts
@@ -10,8 +10,7 @@ export const getPersonData = (origin: string) => {
 		alternateName: "Th3S4mur41",
 		url: "https://th3s4mur41.me/",
 		image: imageUrl,
-		description:
-			"Lead UX Engineer specializing in accessibility, modern web standards, and resilient digital experiences.",
+		description: "Lead UX Engineer & Accessibility Specialist",
 		jobTitle: "Lead UX Engineer",
 		worksFor: {
 			"@type": "Organization",
@@ -38,7 +37,4 @@ export const getWebsiteData = (origin: string) => ({
 	description:
 		"Personal website and blog of Michaël Vanderheyden - Web developer passionate about accessibility, modern web standards, and user-friendly interfaces",
 	image: `${origin}/icons/favicon-512.png`,
-	publisher: {
-		"@id": `${origin}/#person`,
-	},
 });


### PR DESCRIPTION
closes #2104 

This pull request updates the structured data for the website and blog to improve schema accuracy and clarity, focusing on the relationships between the person, website, and publisher entities, as well as refining the description for the person.

**Schema relationship and description updates:**

* Changed the `publisher` reference in the `BlogPostingSchema.astro` component to point to the person entity instead of the website, aligning with schema best practices.
* Updated the person description in `getPersonData` to be more concise: "Lead UX Engineer & Accessibility Specialist".
* Removed the `publisher` property from the website schema data, as it is now redundant or handled elsewhere.