### PR TITLE
chore(blog): add German version link for accessibility post

### DIFF
--- a/src/content/blog/design-for-accessibility--make-your-product-usable-for-all/index.mdx
+++ b/src/content/blog/design-for-accessibility--make-your-product-usable-for-all/index.mdx
@@ -97,3 +97,7 @@ If you’re working on an existing project where accessibility wasn’t initiall
 - **Step-by-Step Improvements**: For existing code, focus on individual issues. With each update, address accessibility concerns. Gradually, your solution will become more accessible, benefiting a broader audience.
 
 Remember: Every small improvement counts — making your product usable for more people is a worthy goal! 🌟
+
+---
+
+*I also wrote a German version of this post for [Global Accessibility Awareness Day (GAAD)](https://accessibility.day/) 2025 on fronta11y: [„Featuritis“: Neues Feature oder Barrierefreiheit?](https://www.fronta11y.org/featuritis-neues-feature-oder-barrierefreiheit/)*


### PR DESCRIPTION
This pull request adds a note to the end of the accessibility blog post, linking to a German-language version of the article published for Global Accessibility Awareness Day (GAAD) 2025. This helps broaden the reach of the content for German-speaking audiences.

- Documentation update:
  - Added a mention and link to a German version of the post for GAAD 2025, published on fronta11y.