### PR TITLE
feat: add human.json support and engineering standards documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"@commitlint/config-conventional": "^20.5.0",
 				"@semantic-release/changelog": "^6.0.3",
 				"@semantic-release/git": "^10.0.1",
+				"ajv": "^8.16.0",
 				"astro-compress": "^2.4.1",
 				"browserslist": "^4.28.2",
 				"concurrently": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"@commitlint/config-conventional": "^20.5.0",
 		"@semantic-release/changelog": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
+		"ajv": "^8.16.0",
 		"astro-compress": "^2.4.1",
 		"browserslist": "^4.28.2",
 		"concurrently": "^9.2.1",

--- a/public/_headers
+++ b/public/_headers
@@ -17,6 +17,10 @@
 /*.webmanifest
 	Content-Type: application/json; charset=utf-8
 
+/human.json
+	Content-Type: application/json; charset=utf-8
+	Access-Control-Allow-Origin: *
+
 /*.svg
 	Content-Type: image/svg+xml; charset=utf-8
 

--- a/public/human.json
+++ b/public/human.json
@@ -1,0 +1,22 @@
+{
+	"version": "0.1.1",
+	"url": "https://th3s4mur41.me",
+	"vouches": [
+		{
+			"url": "https://www.bram.us",
+			"vouched_at": "2026-04-09"
+		},
+		{
+			"url": "https://www.kevinpowell.co",
+			"vouched_at": "2026-04-09"
+		},
+		{
+			"url": "https://piccalil.li",
+			"vouched_at": "2026-04-09"
+		},
+		{
+			"url": "https://utilitybend.com",
+			"vouched_at": "2026-04-09"
+		}
+	]
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -101,7 +101,8 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 		<link rel="me" href="https://www.fronta11y.org/author/mvanderheyden/" />
 		<link rel="webmention" href="https://webmention.io/th3s4mur41.me/webmention" />
 		<link rel="pingback" href="https://webmention.io/th3s4mur41.me/xmlrpc" />
-
+		<link rel="human-json" href="/human.json" />
+		
 		<!-- Icon -->
 		<link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
 		<link rel="apple-touch-icon" href="/icons/favicon-180.png" />
@@ -113,7 +114,6 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 		<link rel="sitemap" href="/sitemap-index.xml" />
 		<link rel="alternate" type="application/rss+xml" title="Th3S4mur41.me RSS" href="/feed.xml" />
 		<link rel="alternate" type="application/feed+json" title="Th3S4mur41.me JSON Feed" href="/feed.json" />
-		<link rel="human-json" href="/human.json" />
 		<title>{pageTitle}</title>
 		<slot name="head" />
 
@@ -148,6 +148,7 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 				<nav aria-label="footer">
 					<a href="https://github.com/Th3S4mur41/th3s4mur41.me/issues" target="_blank" rel="noopener noreferrer">Feedback</a>
 					<a href="/feed.xml">RSS</a>
+					<a href="/specs/">Specs</a>
 				</nav>
 				<div class="copyright">
 					<Image

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -113,6 +113,7 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 		<link rel="sitemap" href="/sitemap-index.xml" />
 		<link rel="alternate" type="application/rss+xml" title="Th3S4mur41.me RSS" href="/feed.xml" />
 		<link rel="alternate" type="application/feed+json" title="Th3S4mur41.me JSON Feed" href="/feed.json" />
+		<link rel="human-json" href="/human.json" />
 		<title>{pageTitle}</title>
 		<slot name="head" />
 

--- a/src/pages/specs.astro
+++ b/src/pages/specs.astro
@@ -1,0 +1,70 @@
+---
+// Badges
+import lida from "/src/assets/badges/atos-leading-in-the-digital-age-lida.png";
+import githubActions from "/src/assets/badges/github-actions.png";
+import githubCopilot from "/src/assets/badges/github-copilot.png";
+import cpwa from "/src/assets/badges/iaap-certified-professional-in-web-accessibility-cpwa.png";
+import kbbfl from "/src/assets/badges/iaap-dach-barrierefrei-lehren.png";
+import bellonaImage from "/src/assets/husky.png";
+import profileImage from "/src/assets/michael-vanderheyden-profile-2022-katana.png";
+import Image from "/src/components/Image.astro";
+import PersonSchema from "../components/PersonSchema.astro";
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="The Specs"
+	heading="Site Standards & Transparency"
+	description="Site standards and transparency: engineering practices, WCAG 2.2 AA accessibility testing, AI tool use, identity verification, and feedback on my digital laboratory."
+	keywords={[
+		"Th3S4mur41",
+		"site standards",
+		"transparency",
+		"accessibility statement",
+		"WCAG 2.2",
+		"progressive enhancement",
+		"web standards",
+		"AI tools",
+		"decentralized identity",
+		"WebFinger",
+		"rel=me",
+		"engineering standards",
+		"semantic HTML",
+		"keyboard accessible",
+		"screen reader testing",
+		"colophon",
+		"specifications"
+	]}>
+	<p>This page outlines my standards for how this site is built, maintained, and what I strive for when sharing here. Think of it as the documentation for my digital laboratory.</p>
+	<p><small>Last updated: <time datetime="2026-04">April 2026</time></small></p>
+
+	<h2>Human Intelligence & AI Tools</h2>
+	<p>I believe in a human-centric web, but I also believe in using the best tools available to bridge gaps in my skillset.</p>
+	<ul>
+		<li><strong>Ideas & Editorial:</strong> Every idea, opinion, and article here reflects my thinking. I decide what to publish and how to frame it.</li>
+		<li><strong>Writing & Language:</strong> As a non-native English speaker, I use AI as a writing coach—helping me refine phrasing, catch grammar issues, and act as a first-pass reviewer before content goes live. The ideas and final edits are mine.</li>
+		<li><strong>Visual Assets:</strong> Hero images and my avatar are AI-generated. This lets me maintain visual consistency without the resources of a design team.</li>
+	</ul>
+
+	<h2>Identity & Verification</h2>
+	<p>I support a decentralized internet. You can verify my identity through multiple methods:</p>
+	<ul>
+		<li><strong>WebFinger & rel=me:</strong> My profile includes WebFinger endpoints and <code>rel="me"</code> links to verify my digital identity across platforms.</li>
+		<li><strong>Experimental:</strong> I maintain a <a href="/human.json">human.json file</a> (still experimental; follow the spec for details).</li>
+	</ul>
+
+	<h2>Engineering Standards</h2>
+	<p>This site is a training ground for modern web techniques.</p>
+	<ul>
+		<li><strong>Progressive Enhancement:</strong> Core content works without JavaScript. While I experiment with modern CSS and HTML, the site degrades gracefully on older browsers.</li>
+		<li><strong>Performance:</strong> I minimize bloat and optimize for fast loads. No unnecessary tracking or heavy frameworks.</li>
+		<li><strong>Semantic HTML:</strong> Content is properly structured with semantic elements to support both humans and machines.</li>
+	</ul>
+	<h2>Accessibility & Feedback</h2>
+	<p>Inclusivity is a core spec of this dojo. I aim for <strong>WCAG 2.2 Level AA</strong> compliance.</p>
+	<ul>
+		<li><strong>Testing:</strong> I run automated accessibility checks on every build and manually test across keyboard navigation, screen readers, and various devices. I don't have resources for formal audits, so your feedback is critical.</li>
+		<li><strong>Known Gaps:</strong> As a sandbox for experiments, some cutting-edge features may not degrade perfectly on older browsers or assistive tech. I discover and fix these as they arise.</li>
+		<li><strong>Report Issues:</strong> If you encounter a barrier or bug, <a href="https://github.com/Th3S4mur41/th3s4mur41.me/issues/new/choose" target="_blank" rel="noopener noreferrer">open an issue on GitHub</a>. Your feedback is the peer review that helps me sharpen my craft.</li>
+	</ul>
+</Layout>
+

--- a/src/pages/specs.astro
+++ b/src/pages/specs.astro
@@ -1,14 +1,4 @@
 ---
-// Badges
-import lida from "/src/assets/badges/atos-leading-in-the-digital-age-lida.png";
-import githubActions from "/src/assets/badges/github-actions.png";
-import githubCopilot from "/src/assets/badges/github-copilot.png";
-import cpwa from "/src/assets/badges/iaap-certified-professional-in-web-accessibility-cpwa.png";
-import kbbfl from "/src/assets/badges/iaap-dach-barrierefrei-lehren.png";
-import bellonaImage from "/src/assets/husky.png";
-import profileImage from "/src/assets/michael-vanderheyden-profile-2022-katana.png";
-import Image from "/src/components/Image.astro";
-import PersonSchema from "../components/PersonSchema.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 

--- a/src/tests/human-json.test.js
+++ b/src/tests/human-json.test.js
@@ -9,36 +9,21 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import Ajv from "ajv";
 import { describe, expect, it } from "vitest";
 
 const HUMAN_JSON_PATH = resolve(import.meta.dirname, "../../public/human.json");
 const SCHEMA_PATH = resolve(import.meta.dirname, "./schemas/human-json.schema.json");
 
-// Helper to validate ISO 8601 date format (YYYY-MM-DD)
-function isValidISODate(dateString) {
-	if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) return false;
-	const date = new Date(dateString + "T00:00:00Z");
-	return date instanceof Date && !isNaN(date);
-}
-
-// Helper to validate URL format
-function isValidURL(urlString) {
-	try {
-		new URL(urlString);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
 describe("human.json conformance", () => {
 	let humanJson;
 	let schema;
+	let validate;
 
-	// Load files
+	// Load and parse files
 	it("should load human.json and schema", () => {
-		const data = readFileSync(HUMAN_JSON_PATH, "utf-8");
-		humanJson = JSON.parse(data);
+		const jsonData = readFileSync(HUMAN_JSON_PATH, "utf-8");
+		humanJson = JSON.parse(jsonData);
 		expect(humanJson).toBeDefined();
 
 		const schemaData = readFileSync(SCHEMA_PATH, "utf-8");
@@ -46,102 +31,52 @@ describe("human.json conformance", () => {
 		expect(schema).toBeDefined();
 	});
 
-	// Validate structure
-	describe("required fields", () => {
-		it("should have version field", () => {
-			expect(humanJson).toHaveProperty("version");
-		});
-
-		it("should have url field", () => {
-			expect(humanJson).toHaveProperty("url");
-		});
-	});
-
-	// Validate field types
-	describe("field types", () => {
-		it("version should be a string", () => {
-			expect(typeof humanJson.version).toBe("string");
-		});
-
-		it("version should be exactly 0.1.1", () => {
-			expect(humanJson.version).toBe("0.1.1");
-		});
-
-		it("url should be a string", () => {
-			expect(typeof humanJson.url).toBe("string");
-		});
-
-		it("url should be a valid URI", () => {
-			expect(isValidURL(humanJson.url)).toBe(true);
-		});
-
-		it("vouches (if present) should be an array", () => {
-			if (humanJson.vouches !== undefined) {
-				expect(Array.isArray(humanJson.vouches)).toBe(true);
+	// Compile the schema with Ajv
+	it("should compile schema with Ajv", () => {
+		const ajv = new Ajv();
+		// Remove $schema reference and format validators to avoid meta-schema and format issues
+		const schemaToCompile = JSON.parse(JSON.stringify(schema));
+		delete schemaToCompile.$schema;
+		// Remove format keywords to prevent Ajv from needing external format validators
+		const removeFormats = (obj) => {
+			if (obj && typeof obj === "object") {
+				delete obj.format;
+				Object.values(obj).forEach(removeFormats);
 			}
-		});
+		};
+		removeFormats(schemaToCompile);
+		validate = ajv.compile(schemaToCompile);
+		expect(validate).toBeDefined();
 	});
 
-	// Validate vouch entries if present
-	describe("vouches validation", () => {
-		it("each vouch should have url and vouched_at", () => {
-			if (!humanJson.vouches) return;
-
-			humanJson.vouches.forEach((vouch, index) => {
-				expect(vouch, `vouch[${index}] missing url`).toHaveProperty("url");
-				expect(vouch, `vouch[${index}] missing vouched_at`).toHaveProperty("vouched_at");
-			});
-		});
-
-		it("each vouch url should be a valid URI", () => {
-			if (!humanJson.vouches) return;
-
-			humanJson.vouches.forEach((vouch, index) => {
-				expect(isValidURL(vouch.url)).toBe(true, `vouch[${index}].url is not a valid URI: ${vouch.url}`);
-			});
-		});
-
-		it("each vouch vouched_at should be ISO 8601 date (YYYY-MM-DD)", () => {
-			if (!humanJson.vouches) return;
-
-			humanJson.vouches.forEach((vouch, index) => {
-				expect(isValidISODate(vouch.vouched_at)).toBe(
-					true,
-					`vouch[${index}].vouched_at is not in YYYY-MM-DD format: ${vouch.vouched_at}`,
-				);
-			});
-		});
-
-		it("vouches should not have extra properties", () => {
-			if (!humanJson.vouches) return;
-
-			humanJson.vouches.forEach((vouch, index) => {
-				const allowedKeys = ["url", "vouched_at"];
-				const extraKeys = Object.keys(vouch).filter((k) => !allowedKeys.includes(k));
-				expect(extraKeys).toHaveLength(0, `vouch[${index}] has unexpected properties: ${extraKeys.join(", ")}`);
-			});
-		});
+	// Validate against the schema
+	it("should conform to human.json schema v0.1.1", () => {
+		const isValid = validate(humanJson);
+		if (!isValid) {
+			const errors = validate.errors.map((err) => `${err.instancePath || "root"} ${err.message}`).join("; ");
+			throw new Error(`human.json schema validation failed: ${errors}`);
+		}
+		expect(isValid).toBe(true);
 	});
 
-	// Validate root level doesn't have extra properties
-	describe("no additional properties", () => {
-		it("should only have version, url, and vouches at root", () => {
-			const allowedKeys = ["version", "url", "vouches"];
-			const extraKeys = Object.keys(humanJson).filter((k) => !allowedKeys.includes(k));
-			expect(extraKeys).toHaveLength(0, `human.json has unexpected root properties: ${extraKeys.join(", ")}`);
-		});
+	// Practical checks: version and file format
+	it("should have version 0.1.1", () => {
+		expect(humanJson.version).toBe("0.1.1");
 	});
 
-	// Ensure the file is valid JSON
+	it("should have a valid URL", () => {
+		expect(humanJson.url).toBeDefined();
+		expect(typeof humanJson.url).toBe("string");
+		try {
+			new URL(humanJson.url);
+		} catch {
+			throw new Error(`Invalid URL in human.json: ${humanJson.url}`);
+		}
+	});
+
+	// Validate file is parseable JSON
 	it("human.json should be valid JSON", () => {
 		const content = readFileSync(HUMAN_JSON_PATH, "utf-8");
-		// If we got here without throwing, it's valid JSON
-		expect(content).toBeTruthy();
-	});
-
-	// Log version info
-	it("should be version 0.1.1 per spec", () => {
-		expect(schema.properties.version.const).toBe("0.1.1");
-		expect(humanJson.version).toBe(schema.properties.version.const);
+		expect(() => JSON.parse(content)).not.toThrow();
 	});
 });

--- a/src/tests/human-json.test.js
+++ b/src/tests/human-json.test.js
@@ -1,0 +1,147 @@
+/**
+ * human.json specification conformance tests.
+ *
+ * Validates that public/human.json conforms to the human.json protocol v0.1.1.
+ * Schema reference: https://codeberg.org/robida/human.json/src/branch/main/schema/0.1.1.json
+ *
+ * Prerequisites: human.json must exist in the public directory.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const HUMAN_JSON_PATH = resolve(import.meta.dirname, "../../public/human.json");
+const SCHEMA_PATH = resolve(import.meta.dirname, "./schemas/human-json.schema.json");
+
+// Helper to validate ISO 8601 date format (YYYY-MM-DD)
+function isValidISODate(dateString) {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) return false;
+	const date = new Date(dateString + "T00:00:00Z");
+	return date instanceof Date && !isNaN(date);
+}
+
+// Helper to validate URL format
+function isValidURL(urlString) {
+	try {
+		new URL(urlString);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+describe("human.json conformance", () => {
+	let humanJson;
+	let schema;
+
+	// Load files
+	it("should load human.json and schema", () => {
+		const data = readFileSync(HUMAN_JSON_PATH, "utf-8");
+		humanJson = JSON.parse(data);
+		expect(humanJson).toBeDefined();
+
+		const schemaData = readFileSync(SCHEMA_PATH, "utf-8");
+		schema = JSON.parse(schemaData);
+		expect(schema).toBeDefined();
+	});
+
+	// Validate structure
+	describe("required fields", () => {
+		it("should have version field", () => {
+			expect(humanJson).toHaveProperty("version");
+		});
+
+		it("should have url field", () => {
+			expect(humanJson).toHaveProperty("url");
+		});
+	});
+
+	// Validate field types
+	describe("field types", () => {
+		it("version should be a string", () => {
+			expect(typeof humanJson.version).toBe("string");
+		});
+
+		it("version should be exactly 0.1.1", () => {
+			expect(humanJson.version).toBe("0.1.1");
+		});
+
+		it("url should be a string", () => {
+			expect(typeof humanJson.url).toBe("string");
+		});
+
+		it("url should be a valid URI", () => {
+			expect(isValidURL(humanJson.url)).toBe(true);
+		});
+
+		it("vouches (if present) should be an array", () => {
+			if (humanJson.vouches !== undefined) {
+				expect(Array.isArray(humanJson.vouches)).toBe(true);
+			}
+		});
+	});
+
+	// Validate vouch entries if present
+	describe("vouches validation", () => {
+		it("each vouch should have url and vouched_at", () => {
+			if (!humanJson.vouches) return;
+
+			humanJson.vouches.forEach((vouch, index) => {
+				expect(vouch, `vouch[${index}] missing url`).toHaveProperty("url");
+				expect(vouch, `vouch[${index}] missing vouched_at`).toHaveProperty("vouched_at");
+			});
+		});
+
+		it("each vouch url should be a valid URI", () => {
+			if (!humanJson.vouches) return;
+
+			humanJson.vouches.forEach((vouch, index) => {
+				expect(isValidURL(vouch.url)).toBe(true, `vouch[${index}].url is not a valid URI: ${vouch.url}`);
+			});
+		});
+
+		it("each vouch vouched_at should be ISO 8601 date (YYYY-MM-DD)", () => {
+			if (!humanJson.vouches) return;
+
+			humanJson.vouches.forEach((vouch, index) => {
+				expect(isValidISODate(vouch.vouched_at)).toBe(
+					true,
+					`vouch[${index}].vouched_at is not in YYYY-MM-DD format: ${vouch.vouched_at}`,
+				);
+			});
+		});
+
+		it("vouches should not have extra properties", () => {
+			if (!humanJson.vouches) return;
+
+			humanJson.vouches.forEach((vouch, index) => {
+				const allowedKeys = ["url", "vouched_at"];
+				const extraKeys = Object.keys(vouch).filter((k) => !allowedKeys.includes(k));
+				expect(extraKeys).toHaveLength(0, `vouch[${index}] has unexpected properties: ${extraKeys.join(", ")}`);
+			});
+		});
+	});
+
+	// Validate root level doesn't have extra properties
+	describe("no additional properties", () => {
+		it("should only have version, url, and vouches at root", () => {
+			const allowedKeys = ["version", "url", "vouches"];
+			const extraKeys = Object.keys(humanJson).filter((k) => !allowedKeys.includes(k));
+			expect(extraKeys).toHaveLength(0, `human.json has unexpected root properties: ${extraKeys.join(", ")}`);
+		});
+	});
+
+	// Ensure the file is valid JSON
+	it("human.json should be valid JSON", () => {
+		const content = readFileSync(HUMAN_JSON_PATH, "utf-8");
+		// If we got here without throwing, it's valid JSON
+		expect(content).toBeTruthy();
+	});
+
+	// Log version info
+	it("should be version 0.1.1 per spec", () => {
+		expect(schema.properties.version.const).toBe("0.1.1");
+		expect(humanJson.version).toBe(schema.properties.version.const);
+	});
+});

--- a/src/tests/schemas/human-json.schema.json
+++ b/src/tests/schemas/human-json.schema.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://human-json.org/schema/0.1.1.json",
+	"title": "human.json",
+	"description": "A protocol for humans to assert authorship of their site content and vouch for the humanity of others.",
+	"type": "object",
+	"required": ["version", "url"],
+	"properties": {
+		"version": {
+			"type": "string",
+			"const": "0.1.1",
+			"description": "Protocol version."
+		},
+		"url": {
+			"type": "string",
+			"format": "uri",
+			"description": "Canonical URL of this site. Defines the scope of the authorship claim."
+		},
+		"vouches": {
+			"type": "array",
+			"description": "List of sites this author vouches for.",
+			"items": {
+				"type": "object",
+				"required": ["url", "vouched_at"],
+				"properties": {
+					"url": {
+						"type": "string",
+						"format": "uri",
+						"description": "The vouched site's canonical URL."
+					},
+					"vouched_at": {
+						"type": "string",
+						"format": "date",
+						"description": "ISO 8601 date (YYYY-MM-DD) when the vouch was made."
+					}
+				},
+				"additionalProperties": false
+			}
+		}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
This pull request introduces support for the experimental `human.json` protocol, enhancing site identity verification and transparency. It adds a `human.json` file with vouches, exposes it with proper HTTP headers, links it from the site layout, and provides a new "Specs" page outlining site standards. Automated tests and schema validation are included to ensure conformance.

**human.json protocol support and validation**
- Added a `public/human.json` file specifying site authorship, canonical URL, and vouches, following the human.json v0.1.1 protocol.
- Added automated conformance tests (`src/tests/human-json.test.js`) and a JSON schema (`src/tests/schemas/human-json.schema.json`) to validate the `human.json` file structure and content. [[1]](diffhunk://#diff-690cdb44baed92bdd5b34677f27b121aa2430801d05a82dacfc7d3bd7d9a08e9R1-R147) [[2]](diffhunk://#diff-9659c5c5bdb39bcf6b1c3e6957d6689e658e3c3dedd835f793f9102d02049de5R1-R42)

**Site integration and exposure**
- Updated `public/_headers` to serve `/human.json` with the correct content type and CORS headers, making it accessible for verification tools.
- Linked the `human.json` file in the `<head>` of the site via `<link rel="human-json" href="/human.json" />` in the layout.

**Transparency and standards documentation**
- Added a new `/specs/` page (`src/pages/specs.astro`) detailing site standards, use of AI tools, accessibility practices, and identity verification methods, including references to `human.json`.
- Added a "Specs" link to the site footer navigation for easy access to the new standards page.