### PR TITLE
docs: update article with new  Mushin release

### DIFF
--- a/content/blog/enhancing-dependabot-auto-merging-a-smarter-more-secure-approach/index.mdx
+++ b/content/blog/enhancing-dependabot-auto-merging-a-smarter-more-secure-approach/index.mdx
@@ -97,7 +97,7 @@ By leveraging **GitHub Rulesets** and a **Webhook-Triggered GitHub App**, auto-m
 
 Want to try this approach for your repositories? Start by setting up a GitHub App and optimizing your branch protection rules — automation has never been this effortless.
 
-## UPDATE -2026-04-16
+## UPDATE - 2026-04-16
 
 I’ve moved the "No-Mind" philosophy to the Edge!  
 I have officially released ***Mushin***, an evolution of the logic described here, rebuilt for **Cloudflare Workers**.

--- a/content/blog/enhancing-dependabot-auto-merging-a-smarter-more-secure-approach/index.mdx
+++ b/content/blog/enhancing-dependabot-auto-merging-a-smarter-more-secure-approach/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: 'Enhancing Dependabot Auto-Merging: A Smarter, More Secure Approach'
 date: 2025-05-09T07:00:00Z
+updated: 2026-04-16T00:00:00Z
 image: enhancing-dependabot-auto-merging.webp
 imageAlt: 'A shield floating in front of some code snippets'
-published: true
 description: >-
   Securely auto-merge Dependabot PRs with GitHub Rulesets and a webhook-driven GitHub App—no PATs, lower risk, and faster, safer dependency updates.
 tags:
@@ -96,6 +96,15 @@ Instead of merely using an app for authentication, I implemented an **app-driven
 By leveraging **GitHub Rulesets** and a **Webhook-Triggered GitHub App**, auto-merging Dependabot PRs is now **safer, more scalable, and easier to deploy**. These enhancements **remove security risks and maintenance efforts** and ensure continuous updates without exposing sensitive credentials.
 
 Want to try this approach for your repositories? Start by setting up a GitHub App and optimizing your branch protection rules — automation has never been this effortless.
+
+## UPDATE -2026-04-16
+
+I’ve moved the "No-Mind" philosophy to the Edge!  
+I have officially released ***Mushin***, an evolution of the logic described here, rebuilt for **Cloudflare Workers**.
+
+While the hosted version is currently private for my personal ecosystem, I have made the **source code 100% public**. You can now deploy your own instance of this bot to your own Cloudflare account in minutes, keeping your automations fast, free, and entirely under your control.
+
+Explore the Source & Deploy Yours: [Th3S4mur41/Mushin](https://github.com/Th3S4mur41/Mushin)
 
 ---
 


### PR DESCRIPTION
This pull request updates the blog post "Enhancing Dependabot Auto-Merging: A Smarter, More Secure Approach" with new information about the release of the open-source Mushin bot and updates the metadata to reflect the latest changes.

Content updates:

* Added an "UPDATE -2026-04-16" section announcing the release of **Mushin**, an open-source evolution of the logic described in the post, now rebuilt for Cloudflare Workers. The update includes a link to the source code and instructions for self-deployment.

Metadata changes:

* Updated the `updated` field in the post frontmatter to `2026-04-16T00:00:00Z` to reflect the new content.