### PR TITLE
feat: update rehypeGithubAlerts to output aside

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,7 @@ import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import { defineConfig } from "astro/config";
 import compress from "astro-compress";
-import { rehypeGithubAlerts } from "rehype-github-alerts";
+import { defaultBuild, rehypeGithubAlerts } from "rehype-github-alerts";
 import {
 	rehypeExternalLinks,
 	rehypeHeadingDates,
@@ -13,10 +13,22 @@ import {
 import { remarkReadingTime } from "./src/plugins/remark-reading-time.js";
 import { SITE_CONFIG } from "./src/utils/config.js";
 
+const rehypeGithubAlertsOptions = {
+	build: (alertOptions, originalChildren) => {
+		const alert = defaultBuild(alertOptions, originalChildren);
+		if (alert?.type === "element") {
+			alert.tagName = "aside";
+		}
+
+		return alert;
+	},
+};
+
 const sharedRehypePlugins = [
 	rehypeHeadingDates,
 	rehypeInjectToc,
 	rehypeViewTransitionNames,
+	[rehypeGithubAlerts, rehypeGithubAlertsOptions],
 	rehypeOptimizeFirstImage,
 	rehypeExternalLinks,
 ];
@@ -24,7 +36,7 @@ const mdxRehypePlugins = [
 	rehypeHeadingDates,
 	rehypeInjectToc,
 	rehypeViewTransitionNames,
-	rehypeGithubAlerts,
+	[rehypeGithubAlerts, rehypeGithubAlertsOptions],
 	rehypeOptimizeFirstImage,
 	rehypeExternalLinks,
 ];

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,6 +18,7 @@ const rehypeGithubAlertsOptions = {
 		const alert = defaultBuild(alertOptions, originalChildren);
 		if (alert?.type === "element") {
 			alert.tagName = "aside";
+			alert.properties = { ...alert.properties, ariaLabel: alertOptions.title };
 		}
 
 		return alert;

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,8 +17,14 @@ const rehypeGithubAlertsOptions = {
 	build: (alertOptions, originalChildren) => {
 		const alert = defaultBuild(alertOptions, originalChildren);
 		if (alert?.type === "element") {
+			const title = typeof alertOptions.title === "string" ? alertOptions.title.trim() : "";
+
 			alert.tagName = "aside";
-			alert.properties = { ...alert.properties, ariaLabel: alertOptions.title };
+			alert.properties = {
+				...alert.properties,
+				// Rehype/HAST properties should use attribute-style ARIA keys.
+				...(title ? { "aria-label": title } : {}),
+			};
 		}
 
 		return alert;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -156,8 +156,7 @@ main {
 	flex-grow: 1;
 }
 
-main,
-aside {
+body > :is(main, aside) {
 	display: grid;
 	grid-template-columns: var(--grid-columns);
 	grid-auto-rows: min-content;


### PR DESCRIPTION
This pull request introduces a customization to the way GitHub-style alerts are rendered in the Astro site and makes a small CSS adjustment to improve layout targeting. The main focus is on customizing the alert elements to use `<aside>` tags for better semantic HTML.

**MDX and Alert Rendering Customization:**

* Updated the import from `rehype-github-alerts` to include `defaultBuild`, and configured the `rehypeGithubAlerts` plugin to render alerts as `<aside>` elements instead of the default tag. This is achieved by providing a custom `build` function in the plugin options. (`astro.config.mjs`) [[1]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL5-R5) [[2]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR16-R39)

**CSS/Layout Improvement:**

* Changed the CSS selector from targeting all `main` and `aside` elements globally to only those that are direct children of `body`, making the grid layout more precise and preventing unintended styling elsewhere. (`src/styles/base.css`)