### PR TITLE
fix: only render alerts as aside with unique label

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,9 +2,10 @@ import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import { defineConfig } from "astro/config";
 import compress from "astro-compress";
-import { defaultBuild, rehypeGithubAlerts } from "rehype-github-alerts";
 import {
 	rehypeExternalLinks,
+	rehypeGithubAlerts,
+	rehypeGithubAlertsA11yOptions,
 	rehypeHeadingDates,
 	rehypeInjectToc,
 	rehypeOptimizeFirstImage,
@@ -13,29 +14,11 @@ import {
 import { remarkReadingTime } from "./src/plugins/remark-reading-time.js";
 import { SITE_CONFIG } from "./src/utils/config.js";
 
-const rehypeGithubAlertsOptions = {
-	build: (alertOptions, originalChildren) => {
-		const alert = defaultBuild(alertOptions, originalChildren);
-		if (alert?.type === "element") {
-			const title = typeof alertOptions.title === "string" ? alertOptions.title.trim() : "";
-
-			alert.tagName = "aside";
-			alert.properties = {
-				...alert.properties,
-				// Rehype/HAST properties should use attribute-style ARIA keys.
-				...(title ? { "aria-label": title } : {}),
-			};
-		}
-
-		return alert;
-	},
-};
-
 const sharedRehypePlugins = [
 	rehypeHeadingDates,
 	rehypeInjectToc,
 	rehypeViewTransitionNames,
-	[rehypeGithubAlerts, rehypeGithubAlertsOptions],
+	[rehypeGithubAlerts, rehypeGithubAlertsA11yOptions],
 	rehypeOptimizeFirstImage,
 	rehypeExternalLinks,
 ];
@@ -43,7 +26,7 @@ const mdxRehypePlugins = [
 	rehypeHeadingDates,
 	rehypeInjectToc,
 	rehypeViewTransitionNames,
-	[rehypeGithubAlerts, rehypeGithubAlertsOptions],
+	[rehypeGithubAlerts, rehypeGithubAlertsA11yOptions],
 	rehypeOptimizeFirstImage,
 	rehypeExternalLinks,
 ];

--- a/content/blog/a11y-tips/keyboard-navigation-testing/index.mdx
+++ b/content/blog/a11y-tips/keyboard-navigation-testing/index.mdx
@@ -49,5 +49,7 @@ This test:
 - Iterates through focusable elements using Tab.
 - Verifies that the Submit button is reachable via keyboard navigation.
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
+> **Human validation is essential**
+>
 > Automated checks like this catch obvious issues early, but they don't replace manual testing with real assistive technologies. Combining automation, manual review, and user feedback ensures inclusive digital experiences.

--- a/content/blog/a11y-tips/labels-validation/index.mdx
+++ b/content/blog/a11y-tips/labels-validation/index.mdx
@@ -39,6 +39,8 @@ Labels are essential for screen reader users and overall accessibility. While au
 - Using voice navigation to verify that elements are reachable and operable by spoken commands.
 
 > [!TIP]
+> **Screen reader setup**
+>
 > If you do test with a screen reader, the results will only be reliable if your environment is correctly set up. The right screen reader depends on both your **operating system** and the **browser** you're testing with. Sara Soueidan's [guide to setting up an accessible testing environment](https://www.sarasoueidan.com/blog/testing-environment-setup/) covers screen reader and browser pairings for macOS and Windows, virtual testing, mobile screen readers, and keyboard configuration.
 
 ## DevTools Accessibility Tree
@@ -102,6 +104,8 @@ Screen readers aren't the only way to validate whether labels are meaningful and
 3. Try commands like **"Tap Read"** or **"Scroll down"** to verify that elements are reachable by their label.
 
 > [!TIP]
+> **Voice Access Numbers**
+> 
 > Android also shows interactive element numbers on screen during a Voice Access session. If an element only gets a number but no spoken label, it is a strong signal the accessible name is missing or unclear.
 
 #### iOS (Voice Control)

--- a/content/blog/a11y-tips/language-attribute/index.mdx
+++ b/content/blog/a11y-tips/language-attribute/index.mdx
@@ -30,4 +30,6 @@ This CodePen demo shows two approaches to language selectors:
 - **Problematic version:** All options are displayed in Farsi without lang attributes. While this demonstrates full localization, it makes it nearly impossible for non-Farsi speakers to identify and switch to their language.
 
 > [!WARNING]
+> **Narrator Limitation**
+>
 > Even with correct lang attributes, some screen readers (like Narrator) may not read content in a language different from the system default, even if that language is installed. This limitation can affect the user experience despite following best practices - another reminder that accessibility is about both standards and real-world testing.

--- a/content/blog/scroll-focus-polyfill/index.mdx
+++ b/content/blog/scroll-focus-polyfill/index.mdx
@@ -78,6 +78,8 @@ However, this requires developers to manually add `tabindex="0"` to every scroll
 Moreover, it’s not ideal to make every `<pre>` focusable, since not all of them will be scrollable.
 
 > [!NOTE]
+> **The Polyfill is a workaround**
+> 
 > The polyfill is only a temporary workaround until Safari implements the expected behavior. It’s not a permanent solution, but it helps bridge the gap in the meantime.
 
 ### Automatically adding tabindex="0" when needed

--- a/content/blog/sda-in-test-automation/index.mdx
+++ b/content/blog/sda-in-test-automation/index.mdx
@@ -101,7 +101,7 @@ If your test scrolls to a section to check for compliance, and that section uses
 </figure>
 
 > [!NOTE]
-> **The Irony** 
+> **The Irony**
 >
 > The site might be perfectly accessible once the user finishes scrolling, but the automation tool lacks the "context" of the scroll-linked state.
 
@@ -130,7 +130,7 @@ There is no "magic button" in current automation frameworks to handle SDA global
 Setting [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) is the standard "go-to" for automation. By setting the browser's emulation to `reduced`, many CSS animations are stripped away.
 
 > [!WARNING]
-> **The Flaw with `prefers-reduced-motion`** 
+> **The Flaw with `prefers-reduced-motion`**
 > 
 > SDA is often used for simple opacity fades (like the CodePen example). Technically, a fade isn't "motion," so many developers don't wrap these in a media query. If the animation isn't wrapped in `@media (prefers-reduced-motion: no-preference)`, the test will still catch the text in a semi-transparent state.
 >
@@ -153,7 +153,7 @@ await page.evaluate(() => window.scrollTo(0, 500));
 ```
 
 > [!WARNING]
-> **The Flaw with mocking** 
+> **The Flaw with mocking**
 >
 > This works for a specific visual regression check of a single component, but it's a nightmare for accessibility (a11y) audits. Tools like axe-core usually scan the entire page. You can't easily "scroll-and-scan" every 10 pixels to ensure every element is at 100% opacity when the scanner hits it. It's simply too much overhead.
 

--- a/content/blog/sda-in-test-automation/index.mdx
+++ b/content/blog/sda-in-test-automation/index.mdx
@@ -91,7 +91,9 @@ The friction isn't just visual; it's functional. Automated accessibility tools l
 If your test scrolls to a section to check for compliance, and that section uses an SDA to fade text in, the tool might catch the text while it's at 30% opacity.
 
 > [!IMPORTANT]
-> **The Result:** Your accessibility audit will report "False Positive" contrast violations even though the final rendered state meets WCAG requirements.
+> **The Result: False Positives**
+> 
+>  Your accessibility audit will report "False Positive" contrast violations even though the final rendered state meets WCAG requirements.
 
 <figure>
 ![Axe DevTools screenshot showing a WCAG 2 AA color‑contrast violation triggered during an SDA fade‑in animation.](axe-core-color-contrast-error.png)
@@ -99,7 +101,9 @@ If your test scrolls to a section to check for compliance, and that section uses
 </figure>
 
 > [!NOTE]
-> **The Irony:** The site might be perfectly accessible once the user finishes scrolling, but the automation tool lacks the "context" of the scroll-linked state.
+> **The Irony** 
+>
+> The site might be perfectly accessible once the user finishes scrolling, but the automation tool lacks the "context" of the scroll-linked state.
 
 ## Scroll-Triggered vs. Scroll-Driven
 
@@ -126,7 +130,9 @@ There is no "magic button" in current automation frameworks to handle SDA global
 Setting [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) is the standard "go-to" for automation. By setting the browser's emulation to `reduced`, many CSS animations are stripped away.
 
 > [!WARNING]
-> **The Flaw:** SDA is often used for simple opacity fades (like the CodePen example). Technically, a fade isn't "motion," so many developers don't wrap these in a media query. If the animation isn't wrapped in `@media (prefers-reduced-motion: no-preference)`, the test will still catch the text in a semi-transparent state.
+> **The Flaw with `prefers-reduced-motion`** 
+> 
+> SDA is often used for simple opacity fades (like the CodePen example). Technically, a fade isn't "motion," so many developers don't wrap these in a media query. If the animation isn't wrapped in `@media (prefers-reduced-motion: no-preference)`, the test will still catch the text in a semi-transparent state.
 >
 > From a user perspective, an opacity fade should probably not be wrapped in `@media (prefers-reduced-motion: no-preference)`. Doing so purely to pass test automation would compromise the experience for users who've enabled `prefers-reduced-motion` for medical reasons (e.g., vestibular disorders).
 
@@ -147,7 +153,9 @@ await page.evaluate(() => window.scrollTo(0, 500));
 ```
 
 > [!WARNING]
-> **The Flaw:** This works for a specific visual regression check of a single component, but it's a nightmare for accessibility (a11y) audits. Tools like axe-core usually scan the entire page. You can't easily "scroll-and-scan" every 10 pixels to ensure every element is at 100% opacity when the scanner hits it. It's simply too much overhead.
+> **The Flaw with mocking** 
+>
+> This works for a specific visual regression check of a single component, but it's a nightmare for accessibility (a11y) audits. Tools like axe-core usually scan the entire page. You can't easily "scroll-and-scan" every 10 pixels to ensure every element is at 100% opacity when the scanner hits it. It's simply too much overhead.
 
 ### Linearizing or Disabling Timelines (The Technical Hack)
 
@@ -168,7 +176,9 @@ body:not([data-a11y-testing]) .animated-element {
 ```
 
 > [!WARNING]
-> **The Flaw:** This isn't "testing the site"—it's testing a modified version. If your CSS override accidentally masks a bug that only exists during animation, your test loses validity.
+> **The Flaw with CSS Overrides**
+>
+> This isn't "testing the site"—it's testing a modified version. If your CSS override accidentally masks a bug that only exists during animation, your test loses validity.
 >
 > Additionally, depending on your test strategy, this may not be possible. For example, running an a11y audit with axe-core doesn't allow custom CSS injection, especially when auditing production websites.
 

--- a/content/blog/the-lean-web/grid-lanes-layout-with-subgrid/index.mdx
+++ b/content/blog/the-lean-web/grid-lanes-layout-with-subgrid/index.mdx
@@ -182,6 +182,8 @@ nav.table-of-contents {
 ```
 
 > [!WARNING]
+> **Chrome Issue**
+>
 > At the time of writing, Chrome supports grid lanes behind experimental flags, but the combination with subgrid is not fully there yet.
 > Treat this as progressive enhancement: the layout should still work without it, just without the sidebar.
 

--- a/content/blog/the-lean-web/grid-lanes-layout-with-subgrid/index.mdx
+++ b/content/blog/the-lean-web/grid-lanes-layout-with-subgrid/index.mdx
@@ -42,6 +42,8 @@ I wanted something that still works with markdown-generated content, with no ext
 I'll walk through the old workaround first, then the grid lanes fix, and finally the anchor positioning tradeoff.
 
 > [!NOTE]
+> **Grid lanes aka. Masonry Layout**
+> 
 > While `grid-lanes` is the technical name of the feature, it was long discussed and documented and might be better known as [Masonry layout](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout).
 
 

--- a/content/blog/tools-that-improve-team-collaboration-and-code-quality/index.mdx
+++ b/content/blog/tools-that-improve-team-collaboration-and-code-quality/index.mdx
@@ -49,6 +49,8 @@ So somebody in the team has to tediously review each pull request to enforce you
 Linters are little tools that you can configure according to your guidelines to verify the code for you.
 
 > [!NOTE]
+> **Linters**
+>
 > There are linters for almost every programming language. For JavaScript the most popular ones are [ESLint](https://eslint.org/) and [JSHint](https://jshint.com/). For CSS you can use [Stylelint](https://stylelint.io/).
 
 You just commit the linter configuration with your code, and they take care of the rest.

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -1,4 +1,5 @@
 ---
+
 import { getImage } from "astro:assets";
 import { getCollection, render } from "astro:content";
 import ArticleCard from "../../components/ArticleCard.astro";
@@ -347,7 +348,7 @@ void [
 	)}
 
 	{!isSeriesPage && article && (
-		<aside slot="aside">
+		<aside slot="aside" aria-label="Related articles">
 			<h2>You might also like</h2>
 			<RelatedArticles currentArticle={article} />
 		</aside>

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,4 +1,5 @@
 export { rehypeExternalLinks } from "./rehype-external-links.js";
+export { rehypeGithubAlerts, rehypeGithubAlertsA11yOptions } from "./rehype-github-alerts-a11y.js";
 export { rehypeHeadingDates } from "./rehype-heading-dates.js";
 export { rehypeInjectToc } from "./rehype-inject-toc.js";
 export { rehypeOptimizeFirstImage } from "./rehype-optimize-first-image.js";

--- a/src/plugins/rehype-github-alerts-a11y.js
+++ b/src/plugins/rehype-github-alerts-a11y.js
@@ -12,9 +12,16 @@ function getCustomAlertTitle(originalChildren) {
 
 	const firstChild = originalChildren[0];
 	if (!firstChild || firstChild.type !== "element" || firstChild.tagName !== "p") return "";
-	if (!Array.isArray(firstChild.children) || firstChild.children.length !== 1) return "";
+	if (!Array.isArray(firstChild.children)) return "";
 
-	const strong = firstChild.children[0];
+	const normalizedChildren = firstChild.children.filter((child) => {
+		if (child.type !== "text") return true;
+		return typeof child.value !== "string" || child.value.trim() !== "";
+	});
+
+	if (normalizedChildren.length !== 1) return "";
+
+	const strong = normalizedChildren[0];
 	if (!strong || strong.type !== "element" || strong.tagName !== "strong") return "";
 
 	return getNodeText(strong).trim();
@@ -27,9 +34,16 @@ function getAlertBodyChildren(originalChildren, customTitle) {
 	return originalChildren.slice(1);
 }
 
+function getAlertTypeTitle(alertOptions) {
+	if (!alertOptions || typeof alertOptions !== "object") return "";
+	if (typeof alertOptions.title !== "string") return "";
+	return alertOptions.title.trim();
+}
+
 export const rehypeGithubAlertsA11yOptions = {
 	build: (alertOptions, originalChildren) => {
 		const customTitle = getCustomAlertTitle(originalChildren);
+		const alertTypeTitle = getAlertTypeTitle(alertOptions);
 		const normalizedChildren = getAlertBodyChildren(originalChildren, customTitle);
 		const normalizedAlertOptions = customTitle ? { ...alertOptions, title: customTitle } : alertOptions;
 		const alert = defaultBuild(normalizedAlertOptions, normalizedChildren);
@@ -37,10 +51,11 @@ export const rehypeGithubAlertsA11yOptions = {
 		if (alert?.type === "element") {
 			if (customTitle) {
 				alert.tagName = "aside";
+				const accessibleLabel = alertTypeTitle ? `${alertTypeTitle}: ${customTitle}` : customTitle;
 				alert.properties = {
 					...alert.properties,
 					// Rehype/HAST properties should use attribute-style ARIA keys.
-					"aria-label": `${alertOptions.title}: ${customTitle}`,
+					"aria-label": accessibleLabel,
 				};
 			} else {
 				alert.tagName = "div";

--- a/src/plugins/rehype-github-alerts-a11y.js
+++ b/src/plugins/rehype-github-alerts-a11y.js
@@ -20,18 +20,27 @@ function getCustomAlertTitle(originalChildren) {
 	return getNodeText(strong).trim();
 }
 
+function getAlertBodyChildren(originalChildren, customTitle) {
+	if (!customTitle) return originalChildren;
+	// When a dedicated title paragraph exists (`**Title**`), remove it from body content
+	// and surface it as the alert heading instead.
+	return originalChildren.slice(1);
+}
+
 export const rehypeGithubAlertsA11yOptions = {
 	build: (alertOptions, originalChildren) => {
-		const alert = defaultBuild(alertOptions, originalChildren);
-		if (alert?.type === "element") {
-			const customTitle = getCustomAlertTitle(originalChildren);
+		const customTitle = getCustomAlertTitle(originalChildren);
+		const normalizedChildren = getAlertBodyChildren(originalChildren, customTitle);
+		const normalizedAlertOptions = customTitle ? { ...alertOptions, title: customTitle } : alertOptions;
+		const alert = defaultBuild(normalizedAlertOptions, normalizedChildren);
 
+		if (alert?.type === "element") {
 			if (customTitle) {
 				alert.tagName = "aside";
 				alert.properties = {
 					...alert.properties,
 					// Rehype/HAST properties should use attribute-style ARIA keys.
-					"aria-label": customTitle,
+					"aria-label": `${alertOptions.title}: ${customTitle}`,
 				};
 			} else {
 				alert.tagName = "div";

--- a/src/plugins/rehype-github-alerts-a11y.js
+++ b/src/plugins/rehype-github-alerts-a11y.js
@@ -1,0 +1,45 @@
+import { defaultBuild, rehypeGithubAlerts } from "rehype-github-alerts";
+
+function getNodeText(node) {
+	if (!node || typeof node !== "object") return "";
+	if (node.type === "text" && typeof node.value === "string") return node.value;
+	if (!Array.isArray(node.children)) return "";
+	return node.children.map((child) => getNodeText(child)).join("");
+}
+
+function getCustomAlertTitle(originalChildren) {
+	if (!Array.isArray(originalChildren) || originalChildren.length === 0) return "";
+
+	const firstChild = originalChildren[0];
+	if (!firstChild || firstChild.type !== "element" || firstChild.tagName !== "p") return "";
+	if (!Array.isArray(firstChild.children) || firstChild.children.length !== 1) return "";
+
+	const strong = firstChild.children[0];
+	if (!strong || strong.type !== "element" || strong.tagName !== "strong") return "";
+
+	return getNodeText(strong).trim();
+}
+
+export const rehypeGithubAlertsA11yOptions = {
+	build: (alertOptions, originalChildren) => {
+		const alert = defaultBuild(alertOptions, originalChildren);
+		if (alert?.type === "element") {
+			const customTitle = getCustomAlertTitle(originalChildren);
+
+			if (customTitle) {
+				alert.tagName = "aside";
+				alert.properties = {
+					...alert.properties,
+					// Rehype/HAST properties should use attribute-style ARIA keys.
+					"aria-label": customTitle,
+				};
+			} else {
+				alert.tagName = "div";
+			}
+		}
+
+		return alert;
+	},
+};
+
+export { rehypeGithubAlerts };


### PR DESCRIPTION
This pull request introduces improvements to accessibility and alert handling in the site's markdown processing, along with various content and documentation enhancements. The most significant changes are the addition of a new `rehype-github-alerts-a11y` plugin for better accessible alerts, updates to plugin imports and usage, and content tweaks to clarify accessibility notes and warnings.

## Accessibility and Alert Handling

* Added a new plugin `rehype-github-alerts-a11y.js` that customizes how alert blocks are rendered for accessibility, including improved ARIA labeling and handling of custom alert titles.
* Updated the Astro config to use `rehypeGithubAlertsA11yOptions` with the `rehypeGithubAlerts` plugin, replacing the previous inline options for more consistent and accessible alert rendering. [[1]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL5-R8) [[2]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL16-R29)
* Exported `rehypeGithubAlerts` and `rehypeGithubAlertsA11yOptions` from the plugins index for use elsewhere in the project.

## Content and Documentation Improvements

* Added or clarified accessibility-related notes and tips in several blog posts, such as emphasizing human validation in accessibility testing, screen reader setup, and voice access numbers. [[1]](diffhunk://#diff-a6f0442e287450520a60863d2dc2635fc157f2c333d3bb73dc9ed3dfe9d5872aR53-R54) [[2]](diffhunk://#diff-6b6af90fd8776fc9a2471f357eade5031cea02e5bbfc494b36356714be29fae7R42-R43) [[3]](diffhunk://#diff-6b6af90fd8776fc9a2471f357eade5031cea02e5bbfc494b36356714be29fae7R107-R108) [[4]](diffhunk://#diff-0177aa48ae9d611f68cbd9ce07d31e6fbdc3a0de3a69ecc22e912b19b73328d9R33-R34) [[5]](diffhunk://#diff-9b349922b253efe93a52fd50c49b157af66d54259742f8458febb913c278769dR81-R82) [[6]](diffhunk://#diff-706dabb5c905437b446649ac29bdd74a76cfd8def9959db5fd161dfacf4e867cR45-R46) [[7]](diffhunk://#diff-706dabb5c905437b446649ac29bdd74a76cfd8def9959db5fd161dfacf4e867cR185-R186) [[8]](diffhunk://#diff-72d20e0bd28638db14f11e7b6efdd30cded301257eca9c1bbe9cf817a54ea306R52-R53)
* Improved warning and note blocks in the "SDA in Test Automation" article for clarity and better accessibility, including more descriptive titles and formatting. [[1]](diffhunk://#diff-f8daf81ae03bdda5f143b075ea0f131b4e33f265785a77f9c693959ef16a63aeL94-R106) [[2]](diffhunk://#diff-f8daf81ae03bdda5f143b075ea0f131b4e33f265785a77f9c693959ef16a63aeL129-R135) [[3]](diffhunk://#diff-f8daf81ae03bdda5f143b075ea0f131b4e33f265785a77f9c693959ef16a63aeL150-R158) [[4]](diffhunk://#diff-f8daf81ae03bdda5f143b075ea0f131b4e33f265785a77f9c693959ef16a63aeL171-R181)

## Minor Accessibility Enhancement

* Added an `aria-label="Related articles"` to the related articles `<aside>` in the article template for better screen reader support. ([src/pages/[section]/[...slug].astroL350-R351](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148L350-R351))

## Issues

closes #2326 
closes #2327 
closes #2329
closes #2330 
closes #2331 
closes #2331 
closes #2332 
closes #2333 
closes #2334 
closes #2336 
closes #2337
closes #2338 
closes #2339 
closes #2342 
closes #2343 
closes #2344 
closes #2345 
closes #2346 
closes #2347 
closes #2348 