### PR TITLE
chore: optimize images

### DIFF
--- a/src/components/Image.astro
+++ b/src/components/Image.astro
@@ -1,5 +1,7 @@
 ---
 
+
+
 import { getImage } from "astro:assets";
 import type { ImageMetadata } from "astro";
 
@@ -64,16 +66,16 @@ const imageContext = sourceContext ?? Astro.url?.pathname ?? "unknown-source";
 const defaultWidths = { xSmall: 320, small: 480, medium: 820, large: 1440 };
 const heroWidths = { xSmall: 480, small: 820, medium: 1280, large: 1920 };
 const shouldUseHeroWidths = !widths && loading === "eager" && sizes === "auto";
-const resolvedWidths = widths ?? (shouldUseHeroWidths ? heroWidths : defaultWidths);
+const presetWidths = shouldUseHeroWidths ? heroWidths : defaultWidths;
+const resolvedWidths = {
+	xSmall: widths?.xSmall ?? presetWidths.xSmall,
+	small: widths?.small ?? presetWidths.small,
+	medium: widths?.medium ?? presetWidths.medium,
+	large: widths?.large ?? presetWidths.large,
+};
 
 if (!isSvg && imageMetadata && originalWidth) {
-	// Normalize widths to ensure all breakpoints have values
-	const {
-		xSmall: xSmallWidth = 320,
-		small: smallWidth = 480,
-		medium: mediumWidth = 820,
-		large: largeWidth = 1440,
-	} = resolvedWidths;
+	const { xSmall: xSmallWidth, small: smallWidth, medium: mediumWidth, large: largeWidth } = resolvedWidths;
 
 	const isJpeg = originalFormat.toLowerCase() === "jpg" || originalFormat.toLowerCase() === "jpeg";
 	const fallbackFormat = isJpeg ? "jpg" : "png";

--- a/src/components/Image.astro
+++ b/src/components/Image.astro
@@ -1,5 +1,7 @@
 ---
 
+
+
 import { getImage } from "astro:assets";
 import type { ImageMetadata } from "astro";
 
@@ -31,7 +33,7 @@ const {
 	width,
 	height,
 	sourceContext,
-	widths = { xSmall: 320, small: 640, medium: 1024, large: 1920 },
+	widths,
 	sizes = "auto",
 	loading = "lazy",
 	decoding = "async",
@@ -61,15 +63,19 @@ let shouldUseRawImage = !imageMetadata;
 const rawImageWidth = width ?? imageMetadata?.width;
 const rawImageHeight = height ?? imageMetadata?.height;
 const imageContext = sourceContext ?? Astro.url?.pathname ?? "unknown-source";
+const defaultWidths = { xSmall: 320, small: 480, medium: 820, large: 1440 };
+const heroWidths = { xSmall: 480, small: 820, medium: 1280, large: 1920 };
+const shouldUseHeroWidths = !widths && loading === "eager" && sizes === "auto";
+const resolvedWidths = widths ?? (shouldUseHeroWidths ? heroWidths : defaultWidths);
 
 if (!isSvg && imageMetadata && originalWidth) {
 	// Normalize widths to ensure all breakpoints have values
 	const {
 		xSmall: xSmallWidth = 320,
-		small: smallWidth = 640,
-		medium: mediumWidth = 1024,
-		large: largeWidth = 1920,
-	} = widths;
+		small: smallWidth = 480,
+		medium: mediumWidth = 820,
+		large: largeWidth = 1440,
+	} = resolvedWidths;
 
 	const isJpeg = originalFormat.toLowerCase() === "jpg" || originalFormat.toLowerCase() === "jpeg";
 	const fallbackFormat = isJpeg ? "jpg" : "png";

--- a/src/components/Image.astro
+++ b/src/components/Image.astro
@@ -1,11 +1,5 @@
 ---
 
-
-
-
-
-
-
 import { getImage } from "astro:assets";
 import type { ImageMetadata } from "astro";
 

--- a/src/components/Image.astro
+++ b/src/components/Image.astro
@@ -2,6 +2,10 @@
 
 
 
+
+
+
+
 import { getImage } from "astro:assets";
 import type { ImageMetadata } from "astro";
 
@@ -95,7 +99,7 @@ if (!isSvg && imageMetadata && originalWidth) {
 		// Generate fallback image (use original format for JPEG, PNG otherwise)
 		fallbackImage = await getImage({
 			src: imageMetadata,
-			width: originalWidth < mediumWidth ? originalWidth : mediumWidth,
+			width: originalWidth < largeWidth ? originalWidth : largeWidth,
 			format: fallbackFormat,
 			quality: 80,
 		});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,9 +35,17 @@ void [Image, profileImg, ArticleCard, Layout, PersonSchema, allPosts];
 <Layout title="Michaël Vanderheyden, UX & Accessibility Lead" heading="">
 	<PersonSchema slot="head" includeWebsite={true} />
 	<div class="intro">
-	<a href='/about/' class="profile"><Image src={profileImg} alt="Michaël holding a katana on a colorful background" loading="eager" sizes="10rem" widths={{ xSmall: 160, small: 240, medium: 320, large: 480 }} /></a>
-	<h1>Hey! My name is <span class="name">Michaël Vanderheyden</span><br> aka. <span class="alias">Th3S4mur41</span></h1> 
-	<p>I'm a passionate web developer dedicated to crafting accessible and user-friendly interfaces that make a difference. I believe that every user—regardless of abilities or context—should experience seamless, intuitive digital interactions. My love for clean code and exploring the latest HTML and CSS features fuels my drive for innovation. With a background in martial arts, I bring the same discipline, respect, and commitment to my work, ensuring high-quality, future-proof solutions.</p>
+		<a href='/about/' class="profile">
+			<Image
+				src={profileImg}
+				alt="Michaël holding a katana on a colorful background"
+				loading="eager"
+				sizes="10rem"
+				widths={{ xSmall: 160, small: 240, medium: 320, large: 480 }}
+			/>
+		</a>
+		<h1>Hey! My name is <span class="name">Michaël Vanderheyden</span><br> aka. <span class="alias">Th3S4mur41</span></h1> 
+		<p>I'm a passionate web developer dedicated to crafting accessible and user-friendly interfaces that make a difference. I believe that every user—regardless of abilities or context—should experience seamless, intuitive digital interactions. My love for clean code and exploring the latest HTML and CSS features fuels my drive for innovation. With a background in martial arts, I bring the same discipline, respect, and commitment to my work, ensuring high-quality, future-proof solutions.</p>
 	</div>
 	<div class="website">
 <h2 class="catchphrase">The web is my dojo</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+
 import { getCollection } from "astro:content";
 import profileImg from "/src/assets/michael-vanderheyden-profile-2025-katana.png";
 import ArticleCard from "../components/ArticleCard.astro";
@@ -34,7 +35,7 @@ void [Image, profileImg, ArticleCard, Layout, PersonSchema, allPosts];
 <Layout title="Michaël Vanderheyden, UX & Accessibility Lead" heading="">
 	<PersonSchema slot="head" includeWebsite={true} />
 	<div class="intro">
-	<a href='/about/' class="profile"><Image src={profileImg} alt="Michaël holding a katana on a colorful background" loading="eager"  /></a>
+	<a href='/about/' class="profile"><Image src={profileImg} alt="Michaël holding a katana on a colorful background" loading="eager" sizes="10rem" widths={{ xSmall: 160, small: 240, medium: 320, large: 480 }} /></a>
 	<h1>Hey! My name is <span class="name">Michaël Vanderheyden</span><br> aka. <span class="alias">Th3S4mur41</span></h1> 
 	<p>I'm a passionate web developer dedicated to crafting accessible and user-friendly interfaces that make a difference. I believe that every user—regardless of abilities or context—should experience seamless, intuitive digital interactions. My love for clean code and exploring the latest HTML and CSS features fuels my drive for innovation. With a background in martial arts, I bring the same discipline, respect, and commitment to my work, ensuring high-quality, future-proof solutions.</p>
 	</div>


### PR DESCRIPTION
This pull request updates the `Image.astro` component to provide more flexible and context-aware image sizing, and applies these improvements to the profile image on the homepage. The changes allow for better control over image widths, especially for "hero" images, and ensure that fallback images are generated at more appropriate sizes.

**Improvements to image sizing logic in `Image.astro`:**

* Added new width presets (`defaultWidths` and `heroWidths`) and logic to automatically select appropriate widths based on the image context (e.g., eager loading with auto sizes uses larger "hero" widths).
* Changed how fallback images are generated: the fallback now uses `largeWidth` instead of `mediumWidth` for better quality on large screens.
* The `widths` prop is now optional and, if not provided, is determined by the new logic; default values for each breakpoint have also been updated to better reflect modern device sizes [[1]](diffhunk://#diff-c4291d955021f6ee7ac2e5da88807fab3c8420cc446a9e3f19f53033def04d24L34-R40) [[2]](diffhunk://#diff-c4291d955021f6ee7ac2e5da88807fab3c8420cc446a9e3f19f53033def04d24R70-R82).

**Usage update in homepage:**

* Updated the profile image on the homepage (`index.astro`) to use the new `widths` prop, specifying custom values for each breakpoint and setting a fixed `sizes` value for consistent rendering.

**Minor code cleanup:**

* Added blank lines for clarity and maintainability in import sections [[1]](diffhunk://#diff-c4291d955021f6ee7ac2e5da88807fab3c8420cc446a9e3f19f53033def04d24R3-R8) [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R2).