### PR TITLE
feat: add notes functionality

### DIFF
--- a/content/notes/standard-site.mdx
+++ b/content/notes/standard-site.mdx
@@ -1,4 +1,5 @@
 ---
+title: "On to the Atmosphere!"
 date: 2026-06-09T00:00:00Z
 description: ''
 tags: 

--- a/content/notes/standard-site.mdx
+++ b/content/notes/standard-site.mdx
@@ -1,0 +1,12 @@
+---
+date: 2026-06-09T00:00:00Z
+description: ''
+tags: 
+  - dx
+  - thoughts
+keywords: []
+---
+
+I've upgraded my website and officially joined the cool kids club on standard.site!
+
+My blog posts are now flying straight into the Atmosphere. 🚀

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -117,35 +117,15 @@ function getPlainTextExcerpt(markdown: string, maxLength = 160): string {
 	return `${text.slice(0, maxLength).trimEnd()}...`;
 }
 
-function extractMarkdownParagraphs(markdown: string): string[] {
-	const body = markdown.replace(/^---[\s\S]*?---\s*/m, "").trim();
-	if (!body) return [];
-
-	return body
-		.split(/\n\s*\n/g)
-		.map((block) =>
-			block
-				.replace(/```[\s\S]*?```/g, " ")
-				.replace(/`([^`]+)`/g, "$1")
-				.replace(/\[(.*?)\]\((.*?)\)/g, "$1")
-				.replace(/[>#*_~=-]/g, " ")
-				.replace(/\s+/g, " ")
-				.trim(),
-		)
-		.filter(Boolean);
-}
-
-const noteParagraphs = section === "notes" && article.body ? extractMarkdownParagraphs(article.body) : [];
-const noteTitleFallback = noteParagraphs[0] ?? null;
-const noteSummaryFallback = noteParagraphs.length > 1 ? getPlainTextExcerpt(noteParagraphs.slice(1).join(" ")) : null;
-
 const resolvedCardTitle = section === "notes"
-	? (article.data.title ?? noteTitleFallback ?? humanizeSlug(article.id))
+	? (article.data.title ?? humanizeSlug(article.id))
 	: (article.data.title ?? humanizeSlug(article.id));
 const resolvedSummary = article.data.description?.trim()
 	? article.data.description
 	: section === "notes"
-		? noteSummaryFallback
+		? article.body
+			? getPlainTextExcerpt(article.body, Number.MAX_SAFE_INTEGER)
+			: null
 		: article.body
 			? getPlainTextExcerpt(article.body)
 			: null;

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -14,8 +14,9 @@ interface ReadingStats {
 interface Props {
 	article: {
 		id: string;
+		body?: string;
 		data: {
-			title: string;
+			title?: string;
 			description?: string;
 			date: string | Date;
 			type?: string;
@@ -92,11 +93,68 @@ const wordCount = typeof candidateWordCount === "number" && Number.isFinite(cand
 const formattedWords = typeof wordCount === "number" ? new Intl.NumberFormat("en-GB").format(wordCount) : null;
 const readingMeta = readingText && formattedWords ? `${readingText} • ${formattedWords} words` : null;
 
+function humanizeSlug(value: string): string {
+	return value
+		.split("/")
+		.filter(Boolean)
+		.pop()
+		?.split("-")
+		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+		.join(" ") ?? value;
+}
+
+function getPlainTextExcerpt(markdown: string, maxLength = 160): string {
+	const text = markdown
+		.replace(/^---[\s\S]*?---\s*/m, "")
+		.replace(/```[\s\S]*?```/g, " ")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(/\[(.*?)\]\((.*?)\)/g, "$1")
+		.replace(/[>#*_~=-]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+
+	if (text.length <= maxLength) return text;
+	return `${text.slice(0, maxLength).trimEnd()}...`;
+}
+
+function extractMarkdownParagraphs(markdown: string): string[] {
+	const body = markdown.replace(/^---[\s\S]*?---\s*/m, "").trim();
+	if (!body) return [];
+
+	return body
+		.split(/\n\s*\n/g)
+		.map((block) =>
+			block
+				.replace(/```[\s\S]*?```/g, " ")
+				.replace(/`([^`]+)`/g, "$1")
+				.replace(/\[(.*?)\]\((.*?)\)/g, "$1")
+				.replace(/[>#*_~=-]/g, " ")
+				.replace(/\s+/g, " ")
+				.trim(),
+		)
+		.filter(Boolean);
+}
+
+const noteParagraphs = section === "notes" && article.body ? extractMarkdownParagraphs(article.body) : [];
+const noteTitleFallback = noteParagraphs[0] ?? null;
+const noteSummaryFallback = noteParagraphs.length > 1 ? getPlainTextExcerpt(noteParagraphs.slice(1).join(" ")) : null;
+
+const resolvedCardTitle = section === "notes"
+	? (article.data.title ?? noteTitleFallback ?? humanizeSlug(article.id))
+	: (article.data.title ?? humanizeSlug(article.id));
+const resolvedSummary = article.data.description?.trim()
+	? article.data.description
+	: section === "notes"
+		? noteSummaryFallback
+		: article.body
+			? getPlainTextExcerpt(article.body)
+			: null;
+
 ---
 
 	<article class:list={["card", "h-entry", { featured, pinned }]}> 
 		<HeadingTag class="p-name" style={`view-transition-name: article-title-${transitionId};`}><a class="u-url" href={resolvedHref}>
-			{article.data.title}</a></HeadingTag>
+			{resolvedCardTitle}</a></HeadingTag>
 		{showType && resolvedType && <span class="type">{resolvedType}</span>}
 		{resolvedImage && (
 			<Image
@@ -107,8 +165,8 @@ const readingMeta = readingText && formattedWords ? `${readingText} • ${format
 				style={`view-transition-name: article-hero-image-${transitionId};`}
 			/>
 		)}
-		{article.data.description && (
-		<p class="p-summary">{article.data.description}</p>
+		{resolvedSummary && (
+		<p class="p-summary">{resolvedSummary}</p>
 		)}
 		<time class="dt-published" datetime={dateValue}>
 			{formatSiteDate(dateObj)}

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -106,6 +106,7 @@ function humanizeSlug(value: string): string {
 function getPlainTextExcerpt(markdown: string, maxLength = 160): string {
 	const text = markdown
 		.replace(/^---[\s\S]*?---\s*/m, "")
+		.replace(/^\s*(?:import|export)\b.*$/gm, " ")
 		.replace(/```[\s\S]*?```/g, " ")
 		.replace(/`([^`]+)`/g, "$1")
 		.replace(/\[(.*?)\]\((.*?)\)/g, "$1")

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -118,18 +118,15 @@ function getPlainTextExcerpt(markdown: string, maxLength = 160): string {
 	return `${text.slice(0, maxLength).trimEnd()}...`;
 }
 
-const resolvedCardTitle = section === "notes"
-	? (article.data.title ?? humanizeSlug(article.id))
-	: (article.data.title ?? humanizeSlug(article.id));
-const resolvedSummary = article.data.description?.trim()
-	? article.data.description
-	: section === "notes"
-		? article.body
-			? getPlainTextExcerpt(article.body, Number.MAX_SAFE_INTEGER)
-			: null
-		: article.body
-			? getPlainTextExcerpt(article.body)
-			: null;
+const NOTE_CARD_SUMMARY_MAX_LENGTH = 300;
+const trimmedTitle = article.data.title?.trim();
+const trimmedDescription = article.data.description?.trim();
+const resolvedCardTitle = trimmedTitle || humanizeSlug(article.id);
+const resolvedSummary = trimmedDescription
+	? trimmedDescription
+	: article.body
+		? getPlainTextExcerpt(article.body, section === "notes" ? NOTE_CARD_SUMMARY_MAX_LENGTH : 160)
+		: null;
 
 ---
 

--- a/src/content.config.js
+++ b/src/content.config.js
@@ -79,6 +79,21 @@ const speakingSchema = ({ image }) =>
 		reactions: z.boolean().optional().default(true),
 	});
 
+const notesSchema = z.object({
+	title: z.string().optional(),
+	type: z.enum(["note"]).optional().default("note"),
+	date: z.date(),
+	updated: z.date().optional(),
+	published: z.boolean().optional().default(true),
+	description: z.string().optional(),
+	slug: z.string().optional(),
+	tags: z.array(z.enum(ALLOWED_TAGS)).optional(),
+	keywords: z.array(z.string()).optional(),
+	canonical: z.string().optional(),
+	syndication: z.array(z.string().url()).optional(),
+	reactions: z.boolean().optional().default(true),
+});
+
 // 5. Create a custom loader wrapper that computes reading-time for collection entries
 function createLoaderWithReadingTime(baseLoader) {
 	return {
@@ -127,5 +142,10 @@ const speaking = defineCollection({
 	schema: speakingSchema,
 });
 
+const notes = defineCollection({
+	loader: glob({ pattern: "**/*.{md,mdx}", base: `${CONTENT_BASE}/notes` }),
+	schema: notesSchema,
+});
+
 // 7. Export a single `collections` object to register your collection(s)
-export const collections = { blog, speaking };
+export const collections = { blog, speaking, notes };

--- a/src/content.config.js
+++ b/src/content.config.js
@@ -80,7 +80,7 @@ const speakingSchema = ({ image }) =>
 	});
 
 const notesSchema = z.object({
-	title: z.string().optional(),
+	title: z.string(),
 	type: z.enum(["note"]).optional().default("note"),
 	date: z.date(),
 	updated: z.date().optional(),

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -145,7 +145,7 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 			<Image class="logo" src={logo} alt="" />
 			<ul>
 				<li><a href="/" aria-current={Astro.url.pathname === '/' ? 'page' : undefined}>Home</a></li>
-				<li><a href="/blog/" aria-current={Astro.url.pathname === '/blog/' ? 'page' : undefined}>Blog</a></li>
+				<li><a href="/blog/" aria-current={Astro.url.pathname.startsWith('/blog/') ? 'page' : undefined}>Blog</a></li>
 				<!-- <li><a href="/projects">Projects</a></li> -->
 				<li><a href="/about/" aria-current={Astro.url.pathname === '/about/' ? 'page' : undefined}>About me</a></li>
 			</ul>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,6 +8,7 @@ import styles from "../index.css?url";
 
 interface Props {
 	title?: string;
+	ogTitle?: string;
 	heading?: string;
 	showHeading?: boolean;
 	tagline?: string;
@@ -31,6 +32,7 @@ const showHeading = Astro.props.showHeading ?? true;
 const pageTitle = Astro.props.tagline
 	? `${siteName} | ${Astro.props.tagline}`
 	: title ? `${title} | ${siteName}` : `${siteName}`;
+const ogTitle = Astro.props.ogTitle?.trim() || title || siteName;
 const header = Astro.props.heading ?? title ?? siteName;
 const currentYear = new Date().getFullYear();
 const slug = Astro.url.pathname.replace(/^\/|\/$/g, "").replace(/\//g, "-") || "home";
@@ -122,7 +124,7 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 		<link rel="apple-touch-icon" href="/icons/favicon-180.png" />
 
 		<!-- Open Graph data -->
-		<OpenGraph title={pageTitle} description={desc} siteName={siteName} image={image} imageAlt={imageAlt} />
+		<OpenGraph title={ogTitle} description={desc} siteName={siteName} image={image} imageAlt={imageAlt} />
 
 		<meta name="generator" content={Astro.generator} />
 		<link rel="sitemap" href="/sitemap-index.xml" />

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -283,7 +283,7 @@ const articleEyebrowText = !isSeriesPage && section === "blog" && series ? serie
 const articleEyebrowHref = !isSeriesPage && section === "blog" && series ? `/blog/${series.slug}/` : null;
 const siteStandardPublicationUri = SITE_CONFIG.atproto?.publicationUri;
 const siteStandardDocumentUri =
-	!isSeriesPage && section === "blog" && article
+	!isSeriesPage && article
 		? (article.data.siteStandardDocumentUri ?? toSiteStandardDocumentUri(SITE_CONFIG.atproto?.did, article.id))
 		: undefined;
 
@@ -344,7 +344,7 @@ void [
 		/>
 	)}
 
-	{!isSeriesPage && section === "blog" && siteStandardDocumentUri && siteStandardPublicationUri && (
+	{!isSeriesPage && siteStandardDocumentUri && siteStandardPublicationUri && (
 		<Fragment slot="head">
 			<link rel="site.standard.document" href={siteStandardDocumentUri} />
 			<link rel="site.standard.publication" href={siteStandardPublicationUri} />

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -239,6 +239,7 @@ function humanizeSlug(value: string): string {
 function getPlainTextExcerpt(markdown: string, maxLength = 160): string {
 	const text = markdown
 		.replace(/^---[\s\S]*?---\s*/m, "")
+		.replace(/^\s*(?:import|export)\b.*$/gm, " ")
 		.replace(/```[\s\S]*?```/g, " ")
 		.replace(/`([^`]+)`/g, "$1")
 		.replace(/\[(.*?)\]\((.*?)\)/g, "$1")

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -250,28 +250,16 @@ function getPlainTextExcerpt(markdown: string, maxLength = 160): string {
 	return `${text.slice(0, maxLength).trimEnd()}...`;
 }
 
-function extractMarkdownParagraphs(markdown: string): string[] {
-	const body = markdown.replace(/^---[\s\S]*?---\s*/m, "").trim();
-	if (!body) return [];
-
-	return body
-		.split(/\n\s*\n/g)
-		.map((block) =>
-			block
-				.replace(/```[\s\S]*?```/g, " ")
-				.replace(/`([^`]+)`/g, "$1")
-				.replace(/\[(.*?)\]\((.*?)\)/g, "$1")
-				.replace(/[>#*_~=-]/g, " ")
-				.replace(/\s+/g, " ")
-				.trim(),
-		)
-		.filter(Boolean);
+function hasH1Heading(markdown: string): boolean {
+	if (!markdown) return false;
+	const content = markdown.replace(/^---[\s\S]*?---\s*/m, "");
+	const markdownH1 = /(^|\n)\s*#(?!#)\s+\S/m;
+	const htmlH1 = /<h1(?:\s[^>]*)?>/i;
+	return markdownH1.test(content) || htmlH1.test(content);
 }
 
-const noteParagraphs = section === "notes" && article?.body ? extractMarkdownParagraphs(article.body) : [];
-const noteFirstParagraph = noteParagraphs[0] ?? null;
-const hasDerivedNoteTitle = section === "notes" && !pageEntry?.data.title && Boolean(noteFirstParagraph);
-const pageTitle = pageEntry?.data.title ?? noteFirstParagraph ?? humanizeSlug(normalizedSlug);
+const pageTitle = pageEntry?.data.title ?? humanizeSlug(normalizedSlug);
+const noteHasH1 = section === "notes" && article?.body ? hasH1Heading(article.body) : false;
 const truncatedTitle = truncateTitle(pageTitle);
 const resolvedDescription = pageEntry?.data.description?.trim()
 	? pageEntry.data.description
@@ -320,6 +308,7 @@ void [
 
 <Layout
   title={truncatedTitle}
+	ogTitle={pageEntry?.data.title ?? pageTitle}
 	showHeading={false}
   image={img}
 	imageAlt={pageEntry?.data.imageAlt}
@@ -384,8 +373,8 @@ void [
 		</>
 	) : (
 		article && (
-			<article class:list={[{ "hide-note-lead": hasDerivedNoteTitle }]}>
-				{section === "notes" && <h1>{pageTitle}</h1>}
+			<article>
+				{section === "notes" && !noteHasH1 && <h1 class="visually-hidden">{pageTitle}</h1>}
 					{articleEyebrowText && (
 						<p class="eyebrow">
 							{articleEyebrowHref ? <a href={articleEyebrowHref}>{articleEyebrowText}</a> : articleEyebrowText}

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -436,7 +436,7 @@ void [
 								)}
 							</p>
 						)}
-						{section !== "notes" && (
+						{article.data.reactions && (
 							<Reactions webmentions={webmentions ?? undefined} syndicationLinks={article.data.syndication} />
 						)}
 					</footer>

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -24,7 +24,7 @@ import type { ProcessedWebmentions } from "../../utils/webmentions";
 import { fetchWebmentions, processWebmentions } from "../../utils/webmentions";
 
 /**
- * Unified dynamic route for both blog posts and speaking entries.
+ * Unified dynamic route for blog posts, speaking entries, and notes.
  * Supports draft preview slugs prefixed with `_draft-` the same way the original
  * individual route files did. Eliminates duplicated logic (images, title truncation, meta setup).
  */
@@ -32,11 +32,16 @@ export async function getStaticPaths() {
 	const now = new Date();
 	const previewFuture = isPreviewFutureContentEnabled();
 
-	const [blogEntries, speakingEntries] = await Promise.all([getCollection("blog"), getCollection("speaking")]);
+	const [blogEntries, speakingEntries, notesEntries] = await Promise.all([
+		getCollection("blog"),
+		getCollection("speaking"),
+		getCollection("notes"),
+	]);
 
 	const allBlogIds = getEntryIds(blogEntries);
 	const visibleBlogEntries = blogEntries.filter((entry: any) => isVisibleContent(entry.data, { now, previewFuture }));
 	const visibleSpeakingEntries = speakingEntries.filter((entry: any) => isVisibleContent(entry.data, { now, previewFuture }));
+	const visibleNotesEntries = notesEntries.filter((entry: any) => isVisibleContent(entry.data, { now, previewFuture }));
 	const visibleBlogByNormalizedId = new Map(
 		visibleBlogEntries.map((entry: any) => [normalizeEntryId(entry.id), entry] as const),
 	);
@@ -68,6 +73,11 @@ export async function getStaticPaths() {
 		props: { article: entry, section: "speaking" },
 	}));
 
+	const notesPaths = visibleNotesEntries.map((entry: any) => ({
+		params: { section: "notes", slug: normalizeEntryId(entry.id) },
+		props: { article: entry, section: "notes" },
+	}));
+
 	const seriesSlugs = new Set<string>();
 	for (const entry of visibleBlogEntries) {
 		const seriesSlug = getSeriesSlug(entry.id);
@@ -79,7 +89,7 @@ export async function getStaticPaths() {
 		props: { section: "blog" },
 	}));
 
-	const paths = [...blogPaths, ...speakingPaths, ...seriesPaths];
+	const paths = [...blogPaths, ...speakingPaths, ...notesPaths, ...seriesPaths];
 
 	return paths;
 }
@@ -90,7 +100,7 @@ const { section, slug } = Astro.params as {
 	slug?: string;
 };
 
-const SUPPORTED_SECTIONS = ["blog", "speaking"] as const;
+const SUPPORTED_SECTIONS = ["blog", "speaking", "notes"] as const;
 type Section = (typeof SUPPORTED_SECTIONS)[number];
 
 if (!section || !SUPPORTED_SECTIONS.includes(section as Section)) {
@@ -226,8 +236,48 @@ function humanizeSlug(value: string): string {
 		.join(" ") ?? value;
 }
 
-const pageTitle = pageEntry?.data.title ?? humanizeSlug(normalizedSlug);
+function getPlainTextExcerpt(markdown: string, maxLength = 160): string {
+	const text = markdown
+		.replace(/^---[\s\S]*?---\s*/m, "")
+		.replace(/```[\s\S]*?```/g, " ")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(/\[(.*?)\]\((.*?)\)/g, "$1")
+		.replace(/[>#*_~=-]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+
+	if (text.length <= maxLength) return text;
+	return `${text.slice(0, maxLength).trimEnd()}...`;
+}
+
+function extractMarkdownParagraphs(markdown: string): string[] {
+	const body = markdown.replace(/^---[\s\S]*?---\s*/m, "").trim();
+	if (!body) return [];
+
+	return body
+		.split(/\n\s*\n/g)
+		.map((block) =>
+			block
+				.replace(/```[\s\S]*?```/g, " ")
+				.replace(/`([^`]+)`/g, "$1")
+				.replace(/\[(.*?)\]\((.*?)\)/g, "$1")
+				.replace(/[>#*_~=-]/g, " ")
+				.replace(/\s+/g, " ")
+				.trim(),
+		)
+		.filter(Boolean);
+}
+
+const noteParagraphs = section === "notes" && article?.body ? extractMarkdownParagraphs(article.body) : [];
+const noteFirstParagraph = noteParagraphs[0] ?? null;
+const hasDerivedNoteTitle = section === "notes" && !pageEntry?.data.title && Boolean(noteFirstParagraph);
+const pageTitle = pageEntry?.data.title ?? noteFirstParagraph ?? humanizeSlug(normalizedSlug);
 const truncatedTitle = truncateTitle(pageTitle);
+const resolvedDescription = pageEntry?.data.description?.trim()
+	? pageEntry.data.description
+	: article?.body
+		? getPlainTextExcerpt(article.body)
+		: undefined;
 const translations = pageEntry?.data.translations?.map((t: any) => ({ language: t.language, url: t.url })) ?? undefined;
 const articleEyebrowText = !isSeriesPage && section === "blog" && series ? series.title : article?.data.eyebrow;
 const articleEyebrowHref = !isSeriesPage && section === "blog" && series ? `/blog/${series.slug}/` : null;
@@ -273,7 +323,7 @@ void [
 	showHeading={false}
   image={img}
 	imageAlt={pageEntry?.data.imageAlt}
-  description={pageEntry?.data.description}
+	description={resolvedDescription}
   keywords={pageEntry?.data.keywords}
 	noIndex={!isSeriesPage && pageEntry?.data.published === false}
   canonical={pageEntry?.data.canonical ?? undefined}
@@ -334,48 +384,56 @@ void [
 		</>
 	) : (
 		article && (
-			<article>
+			<article class:list={[{ "hide-note-lead": hasDerivedNoteTitle }]}>
+				{section === "notes" && <h1>{pageTitle}</h1>}
 					{articleEyebrowText && (
 						<p class="eyebrow">
 							{articleEyebrowHref ? <a href={articleEyebrowHref}>{articleEyebrowText}</a> : articleEyebrowText}
 						</p>
 					)}
-					{ArticleContent && <ArticleContent components={{ img: Image }} />}
+					{ArticleContent && (
+						<ArticleContent components={{ img: Image }} />
+					)}
 					<footer>
 						<p class="published">
 							Published on <time datetime={article.data.date}>{formatSiteDate(article.data.date)}</time>
-							{article.data.canonical && (
+							{section !== "notes" && article.data.canonical && (
 								<>
 									{" "}via <a href={article.data.canonical} target="_blank" rel="noopener noreferrer">{new URL(article.data.canonical).hostname.replace(/^www\./, "").split(".")[0]}</a>
 								</>
-							)} by{" "}
-						<a href="/about/" class="author">Michaël Vanderheyden</a>
-						{article.data.coauthors && article.data.coauthors.length > 0 && (
-							article.data.coauthors.map((coauthor, index) => (
+							)}
+							{section !== "notes" && (
 								<>
-									{index === article.data.coauthors.length - 1 ? " and " : ", "}
-									{coauthor.url ? (
-										<a href={coauthor.url} class="author" target="_blank" rel="external noopener">{coauthor.name}</a>
-									) : (
-										<span class="author">{coauthor.name}</span>
-									)}
+									{" "}by <a href="/about/" class="author">Michaël Vanderheyden</a>
 								</>
-							))
-						)}
+							)}
+							{section !== "notes" && article.data.coauthors && article.data.coauthors.length > 0 && (
+								article.data.coauthors.map((coauthor: any, index: number) => (
+									<>
+										{index === article.data.coauthors.length - 1 ? " and " : ", "}
+										{coauthor.url ? (
+											<a href={coauthor.url} class="author" target="_blank" rel="external noopener">{coauthor.name}</a>
+										) : (
+											<span class="author">{coauthor.name}</span>
+										)}
+									</>
+								))
+							)}
 						</p>
-						{article.data.updated && (
+						{section !== "notes" && article.data.updated && (
 							<p class="updated">
 								Last updated on <time datetime={article.data.updated}>{formatSiteDate(article.data.updated)}</time>
 							</p>
 						)}
-						<button type="button" class="share-button hidden">
-							<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
-								<path d="M176,160a39.89,39.89,0,0,0-28.62,12.09l-46.1-29.63a39.8,39.8,0,0,0,0-28.92l46.1-29.63a40,40,0,1,0-8.66-13.45l-46.1,29.63a40,40,0,1,0,0,55.82l46.1,29.63A40,40,0,1,0,176,160Zm0-128a24,24,0,1,1-24,24A24,24,0,0,1,176,32ZM64,152a24,24,0,1,1,24-24A24,24,0,0,1,64,152Zm112,72a24,24,0,1,1,24-24A24,24,0,0,1,176,224Z"></path>
-							</svg>
-							<span>Share</span>
-						</button>
-						
-						{article.data.tags && article.data.tags.length > 0 && (
+						{section !== "notes" && (
+							<button type="button" class="share-button hidden">
+								<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 256 256" aria-hidden="true" focusable="false">
+									<path d="M176,160a39.89,39.89,0,0,0-28.62,12.09l-46.1-29.63a39.8,39.8,0,0,0,0-28.92l46.1-29.63a40,40,0,1,0-8.66-13.45l-46.1,29.63a40,40,0,1,0,0,55.82l46.1,29.63A40,40,0,1,0,176,160Zm0-128a24,24,0,1,1-24,24A24,24,0,0,1,176,32ZM64,152a24,24,0,1,1,24-24A24,24,0,0,1,64,152Zm112,72a24,24,0,1,1,24-24A24,24,0,0,1,176,224Z"></path>
+								</svg>
+								<span>Share</span>
+							</button>
+						)}
+						{section !== "notes" && article.data.tags && article.data.tags.length > 0 && (
 							<p class="tags">
 								<strong>Tags:</strong>{" "}
 								{sortTags(article.data.tags).map((tag, index) =>
@@ -389,13 +447,15 @@ void [
 								)}
 							</p>
 						)}
-						<Reactions webmentions={webmentions ?? undefined} syndicationLinks={article.data.syndication} />
+						{section !== "notes" && (
+							<Reactions webmentions={webmentions ?? undefined} syndicationLinks={article.data.syndication} />
+						)}
 					</footer>
 				</article>
 		)
 	)}
 
-	{!isSeriesPage && article && (
+	{!isSeriesPage && section !== "notes" && article && (
 		<aside slot="aside" aria-label="Related articles">
 			<h2>You might also like</h2>
 			<RelatedArticles currentArticle={article} />

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -259,7 +259,8 @@ function hasH1Heading(markdown: string): boolean {
 	return markdownH1.test(content) || htmlH1.test(content);
 }
 
-const pageTitle = pageEntry?.data.title ?? humanizeSlug(normalizedSlug);
+const trimmedEntryTitle = pageEntry?.data.title?.trim();
+const pageTitle = trimmedEntryTitle || humanizeSlug(normalizedSlug);
 const noteHasH1 = section === "notes" && article?.body ? hasH1Heading(article.body) : false;
 const truncatedTitle = truncateTitle(pageTitle);
 const resolvedDescription = pageEntry?.data.description?.trim()
@@ -309,7 +310,7 @@ void [
 
 <Layout
   title={truncatedTitle}
-	ogTitle={pageEntry?.data.title ?? pageTitle}
+	ogTitle={trimmedEntryTitle || pageTitle}
 	showHeading={false}
   image={img}
 	imageAlt={pageEntry?.data.imageAlt}

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -16,6 +16,7 @@ const previewFuture = isPreviewFutureContentEnabled();
 const allBlogEntries = await getCollection("blog");
 const blog = allBlogEntries.filter(({ data }: any) => isVisibleContent(data, { now, previewFuture }));
 const speaking = await getCollection("speaking", ({ data }: any) => isVisibleContent(data, { now, previewFuture }));
+const notes = await getCollection("notes", ({ data }: any) => isVisibleContent(data, { now, previewFuture }));
 const blogIds = getEntryIds(allBlogEntries);
 
 const blogPosts = blog.filter((entry: any) => !isSeriesContainerId(entry.id, blogIds));
@@ -24,6 +25,7 @@ const blogPosts = blog.filter((entry: any) => !isSeriesContainerId(entry.id, blo
 const combined = [
 	...blogPosts.map((entry: any) => ({ section: "blog" as const, entry })),
 	...speaking.map((entry: any) => ({ section: "speaking" as const, entry })),
+	...notes.map((entry: any) => ({ section: "notes" as const, entry })),
 ].sort((a, b) => new Date(b.entry.data.date).getTime() - new Date(a.entry.data.date).getTime());
 
 // Get all unique tags from published content

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -25,12 +25,14 @@ export async function getStaticPaths() {
 	const allBlogEntries = await getCollection("blog");
 	const blog = allBlogEntries.filter(({ data }: any) => isVisibleContent(data, { now, previewFuture }));
 	const speaking = await getCollection("speaking", ({ data }: any) => isVisibleContent(data, { now, previewFuture }));
+	const notes = await getCollection("notes", ({ data }: any) => isVisibleContent(data, { now, previewFuture }));
 	const blogIds = getEntryIds(allBlogEntries);
 	const blogPosts = blog.filter((entry: any) => !isSeriesContainerId(entry.id, blogIds));
 
 	const allContent = [
 		...blogPosts.map((entry: any) => ({ section: "blog" as const, entry })),
 		...speaking.map((entry: any) => ({ section: "speaking" as const, entry })),
+		...notes.map((entry: any) => ({ section: "notes" as const, entry })),
 	];
 
 	// Get all unique tags that have content
@@ -58,6 +60,7 @@ const previewFuture = isPreviewFutureContentEnabled();
 const allBlogEntries = await getCollection("blog");
 const blog = allBlogEntries.filter(({ data }: any) => isVisibleContent(data, { now, previewFuture }));
 const speaking = await getCollection("speaking", ({ data }: any) => isVisibleContent(data, { now, previewFuture }));
+const notes = await getCollection("notes", ({ data }: any) => isVisibleContent(data, { now, previewFuture }));
 
 const blogIds = getEntryIds(allBlogEntries);
 const blogPosts = blog.filter((entry: any) => !isSeriesContainerId(entry.id, blogIds));
@@ -65,6 +68,7 @@ const blogPosts = blog.filter((entry: any) => !isSeriesContainerId(entry.id, blo
 const allContent = [
 	...blogPosts.map((entry: any) => ({ section: "blog" as const, entry })),
 	...speaking.map((entry: any) => ({ section: "speaking" as const, entry })),
+	...notes.map((entry: any) => ({ section: "notes" as const, entry })),
 ];
 
 // Build tag navigation from all visible content.

--- a/src/pages/feed.json.js
+++ b/src/pages/feed.json.js
@@ -16,9 +16,10 @@ export async function GET(context) {
 	const now = new Date();
 	const previewFuture = isPreviewFutureContentEnabled();
 
-	const [allBlogEntries, speakingEntries] = await Promise.all([
+	const [allBlogEntries, speakingEntries, notesEntries] = await Promise.all([
 		getCollection("blog"),
 		getCollection("speaking", ({ data }) => isVisibleContent(data, { now, previewFuture })),
+		getCollection("notes", ({ data }) => isVisibleContent(data, { now, previewFuture })),
 	]);
 	const blogEntryIds = getEntryIds(allBlogEntries);
 	const blogEntries = allBlogEntries.filter((entry) => isVisibleContent(entry.data, { now, previewFuture }));
@@ -67,6 +68,7 @@ export async function GET(context) {
 		await Promise.all([
 			...blogPosts.map((entry) => toItem("blog", entry)),
 			...speakingEntries.map((entry) => toItem("speaking", entry)),
+			...notesEntries.map((entry) => toItem("notes", entry)),
 		])
 	)
 		.sort((a, b) => (b.date_published ?? "").localeCompare(a.date_published ?? ""))

--- a/src/pages/feed.json.js
+++ b/src/pages/feed.json.js
@@ -1,7 +1,7 @@
 import { getCollection } from "astro:content";
 import { getEntryIds, isSeriesContainerId } from "../utils/contentSeries";
 import { isPreviewFutureContentEnabled, isVisibleContent } from "../utils/contentVisibility";
-import { getHeroImageUrl, renderBodyToHtml } from "../utils/feedHelpers";
+import { getFeedSummary, getFeedTitle, getHeroImageUrl, renderBodyToHtml } from "../utils/feedHelpers";
 
 const FEED_LIMIT = 50;
 
@@ -53,8 +53,8 @@ export async function GET(context) {
 			id: url,
 			url,
 			external_url: entry.data.canonical ?? undefined,
-			title: entry.data.title,
-			summary: entry.data.description ?? undefined,
+			title: getFeedTitle(entry),
+			summary: getFeedSummary(entry) || undefined,
 			image: heroImageUrl ?? undefined,
 			content_html: contentHtml ?? undefined,
 			date_published: entry.data.date.toISOString(),

--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -2,7 +2,7 @@ import { getCollection } from "astro:content";
 import rss from "@astrojs/rss";
 import { getEntryIds, isSeriesContainerId } from "../utils/contentSeries";
 import { isPreviewFutureContentEnabled, isVisibleContent } from "../utils/contentVisibility";
-import { getHeroImageUrl, renderBodyToHtml } from "../utils/feedHelpers";
+import { getFeedSummary, getFeedTitle, getHeroImageUrl, renderBodyToHtml } from "../utils/feedHelpers";
 
 const escapeXmlText = (value) =>
 	value
@@ -65,8 +65,8 @@ export async function GET(context) {
 			}
 
 			return {
-				title: entry.data.title,
-				description: sanitizeDescription(entry.data.description ?? ""),
+				title: getFeedTitle(entry),
+				description: sanitizeDescription(getFeedSummary(entry)),
 				pubDate: entry.data.date,
 				link: `/${section}/${entry.id}/`,
 				categories: entry.data.tags ?? [],

--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -35,9 +35,10 @@ export async function GET(context) {
 	const feedUrl = new URL("/feed.xml", site).href;
 	const iconUrl = new URL("/icons/favicon-512.png", site).href;
 
-	const [allBlogEntries, speakingEntries] = await Promise.all([
+	const [allBlogEntries, speakingEntries, notesEntries] = await Promise.all([
 		getCollection("blog"),
 		getCollection("speaking", ({ data }) => isVisibleContent(data, { now, previewFuture })),
+		getCollection("notes", ({ data }) => isVisibleContent(data, { now, previewFuture })),
 	]);
 	const blogEntryIds = getEntryIds(allBlogEntries);
 	const blogEntries = allBlogEntries.filter((entry) => isVisibleContent(entry.data, { now, previewFuture }));
@@ -46,6 +47,7 @@ export async function GET(context) {
 	const sortedEntries = [
 		...blogPosts.map((entry) => ({ section: "blog", entry })),
 		...speakingEntries.map((entry) => ({ section: "speaking", entry })),
+		...notesEntries.map((entry) => ({ section: "notes", entry })),
 	]
 		.sort((a, b) => b.entry.data.date.valueOf() - a.entry.data.date.valueOf())
 		.slice(0, FEED_LIMIT);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,8 +23,12 @@ const speaking = (await getCollection("speaking", ({ data }: any) => isVisibleCo
 	(entry: any) => ({ ...entry, section: "speaking" }),
 );
 
+const notes = (await getCollection("notes", ({ data }: any) => isVisibleContent(data, { now, previewFuture }))).map(
+	(entry: any) => ({ ...entry, section: "notes" }),
+);
+
 // Combine and sort all posts by date, then take the 3 most recent
-const allPosts = [...blog, ...speaking]
+const allPosts = [...blog, ...speaking, ...notes]
 	.sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
 	.slice(0, 3);
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -600,3 +600,8 @@ blockquote:where(:not([class], [cite])) {
 		display: contents;
 	}
 }
+
+.visually-hidden {
+	position: absolute; /* take out of document flow */
+	clip-path: circle(0); /* reduce clickable area to nothing */
+}

--- a/src/styles/components/article-card.css
+++ b/src/styles/components/article-card.css
@@ -120,7 +120,7 @@ article.card {
 		color: var(--color-subtle-text);
 	}
 
-	&.featured {
+	&.featured:has(img) {
 		grid-template-columns: [image-start] 0.5em [title-start teaser-start date-start type-start] 1fr [date-end meta-start] auto [meta-end
 				title-end teaser-end type-end] 0.5em [image-end];
 		grid-template-rows: [image-start type-start] auto [image-end type-end meta-start date-start] auto [meta-end date-end
@@ -141,5 +141,31 @@ article.card {
 	}
 	&:has(a:focus-visible) {
 		outline: 2px solid var(--color-accent);
+	}
+
+	/* Notes */
+	&:not(:has(img)) {
+		grid-template-columns: 0.5em [title-start teaser-start type-start] auto [type-end date-start] 1fr [title-end
+				teaser-end date-end] 0.5em;
+		grid-template-rows: 0.5em [type-start date-start] auto [type-end date-end title-start] auto [title-end teaser-start] auto [teaser-end] 0.5em;
+		column-gap: 0.5rem;
+		& .type {
+			background: var(--color-accent);
+			color: var(--color-bg);
+		}
+		& time {
+			align-self: center;
+		}
+		& h2,
+		h3,
+		p {
+			color: var(--color-text);
+			font-size: 1.5em;
+			font-weight: 300;
+			line-height: 1.2;
+			letter-spacing: 0.05ch;
+			text-transform: unset;
+			text-wrap: balance;
+		}
 	}
 }

--- a/src/styles/components/article-card.css
+++ b/src/styles/components/article-card.css
@@ -156,9 +156,7 @@ article.card {
 		& time {
 			align-self: center;
 		}
-		& h2,
-		h3,
-		p {
+		& :is(h2, h3, p) {
 			color: var(--color-text);
 			font-size: 1.5em;
 			font-weight: 300;

--- a/src/styles/pages/blog.css
+++ b/src/styles/pages/blog.css
@@ -446,9 +446,5 @@ body[class^="notes-"] {
 			text-transform: unset;
 			text-wrap: balance;
 		}
-
-		&.hide-note-lead > p:first-of-type {
-			display: none;
-		}
 	}
 }

--- a/src/styles/pages/blog.css
+++ b/src/styles/pages/blog.css
@@ -429,3 +429,26 @@ baseline-status {
 	display: grid;
 	grid-template-columns: subgrid;
 }
+
+body[class^="notes-"] {
+	main {
+		grid-auto-rows: 1fr;
+	}
+	article {
+		align-self: center;
+
+		& > h1,
+		& > p {
+			font-size: 1.5em;
+			font-weight: 300;
+			line-height: 1.2;
+			letter-spacing: 0.05ch;
+			text-transform: unset;
+			text-wrap: balance;
+		}
+
+		&.hide-note-lead > p:first-of-type {
+			display: none;
+		}
+	}
+}

--- a/src/utils/feedHelpers.js
+++ b/src/utils/feedHelpers.js
@@ -281,6 +281,32 @@ function stripH1() {
 	};
 }
 
+function humanizeSlug(value) {
+	return (
+		value
+			.split("/")
+			.filter(Boolean)
+			.pop()
+			?.split("-")
+			.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+			.join(" ") ?? value
+	);
+}
+
+function getPlainTextExcerpt(markdown, maxLength = 160) {
+	const text = markdown
+		.replace(/^---[\s\S]*?---\s*/m, "")
+		.replace(/```[\s\S]*?```/g, " ")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(/\[(.*?)\]\((.*?)\)/g, "$1")
+		.replace(/[>#*_~=-]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+
+	if (text.length <= maxLength) return text;
+	return `${text.slice(0, maxLength).trimEnd()}...`;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -325,6 +351,31 @@ export async function renderBodyToHtml(entry, site) {
 		.process(body);
 
 	return String(result);
+}
+
+/**
+ * Resolve a stable feed item title for entries that may omit frontmatter title
+ * (for example short-form notes).
+ *
+ * @param {object} entry - Astro content entry.
+ * @returns {string}
+ */
+export function getFeedTitle(entry) {
+	return entry?.data?.title?.trim() || humanizeSlug(entry?.id ?? "untitled");
+}
+
+/**
+ * Resolve a feed summary using frontmatter description when present, otherwise
+ * derive a short excerpt from the entry body.
+ *
+ * @param {object} entry - Astro content entry.
+ * @param {number} [maxLength=160] - Maximum summary length.
+ * @returns {string}
+ */
+export function getFeedSummary(entry, maxLength = 160) {
+	if (entry?.data?.description?.trim()) return entry.data.description.trim();
+	if (entry?.body) return getPlainTextExcerpt(entry.body, maxLength);
+	return "";
 }
 
 /**

--- a/src/utils/feedHelpers.js
+++ b/src/utils/feedHelpers.js
@@ -12,14 +12,16 @@ import { visit } from "unist-util-visit";
 const CONTENT_ROOT = "/content";
 const BLOG_CONTENT_SEGMENT = `${CONTENT_ROOT}/blog/`;
 const SPEAKING_CONTENT_SEGMENT = `${CONTENT_ROOT}/speaking/`;
+const NOTES_CONTENT_SEGMENT = `${CONTENT_ROOT}/notes/`;
 
 // Eagerly import all content images so they can be resolved to processed asset URLs.
 export const blogImages = import.meta.glob("/content/blog/**/*.{jpg,jpeg,png,webp,gif,avif,svg}", { eager: true });
 export const speakingImages = import.meta.glob("/content/speaking/**/*.{jpg,jpeg,png,webp,gif,avif,svg}", {
 	eager: true,
 });
+export const notesImages = import.meta.glob("/content/notes/**/*.{jpg,jpeg,png,webp,gif,avif,svg}", { eager: true });
 
-const IMAGE_POOLS = { blog: blogImages, speaking: speakingImages };
+const IMAGE_POOLS = { blog: blogImages, speaking: speakingImages, notes: notesImages };
 
 /**
  * Image format to request when processing feed images via `getImage`.
@@ -104,6 +106,7 @@ function getSectionFromFilePath(filePath) {
 	if (!filePath) return null;
 	if (filePath.includes(BLOG_CONTENT_SEGMENT) || filePath.startsWith("content/blog/")) return "blog";
 	if (filePath.includes(SPEAKING_CONTENT_SEGMENT) || filePath.startsWith("content/speaking/")) return "speaking";
+	if (filePath.includes(NOTES_CONTENT_SEGMENT) || filePath.startsWith("content/notes/")) return "notes";
 	return null;
 }
 

--- a/src/utils/feedHelpers.js
+++ b/src/utils/feedHelpers.js
@@ -296,6 +296,7 @@ function humanizeSlug(value) {
 function getPlainTextExcerpt(markdown, maxLength = 160) {
 	const text = markdown
 		.replace(/^---[\s\S]*?---\s*/m, "")
+		.replace(/^\s*(?:import|export)\b.*$/gm, " ")
 		.replace(/```[\s\S]*?```/g, " ")
 		.replace(/`([^`]+)`/g, "$1")
 		.replace(/\[(.*?)\]\((.*?)\)/g, "$1")


### PR DESCRIPTION
This pull request introduces a new "notes" section to the website, alongside various improvements to content handling and presentation. The changes include adding support for notes in the content model, updating dynamic routing and content collection logic, and refining how articles and notes are rendered and displayed. Additionally, there are enhancements to metadata handling and minor UI improvements.

**Support for Notes Section**

* Added a new `notes` collection with its own schema in `src/content.config.js`, enabling notes as a first-class content type. [[1]](diffhunk://#diff-f78604c567e52b762610ec9a58e5538504a7c0956e22ed8c0c70cbd37e978aceR82-R96) [[2]](diffhunk://#diff-f78604c567e52b762610ec9a58e5538504a7c0956e22ed8c0c70cbd37e978aceR145-R151)
* Updated dynamic routing in `[section]/[...slug].astro` to support notes, including static path generation and section validation. ([src/pages/[section]/[...slug].astroL27-R44](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148L27-R44), [src/pages/[section]/[...slug].astroR76-R80](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148R76-R80), [src/pages/[section]/[...slug].astroL82-R92](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148L82-R92), [src/pages/[section]/[...slug].astroL93-R103](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148L93-R103))
* Updated blog and tag pages to include notes in listings and tag navigation. [[1]](diffhunk://#diff-7968dd4f35b1d48d90e332e78caa762fe415e5d9fdc252bfdb4f80373f925e0bR19) [[2]](diffhunk://#diff-7968dd4f35b1d48d90e332e78caa762fe415e5d9fdc252bfdb4f80373f925e0bR28) [src/pages/blog/tags/[tag].astroR28-R35](diffhunk://#diff-4469c8166b8219ae5b226def1957ce1fce24e1df3605f4dce7658424bb2195b7R28-R35), [src/pages/blog/tags/[tag].astroR63-R71](diffhunk://#diff-4469c8166b8219ae5b226def1957ce1fce24e1df3605f4dce7658424bb2195b7R63-R71))

**Rendering and Presentation Improvements**

* Enhanced article rendering to handle notes differently: hides certain metadata (like canonical links, coauthors, tags, and share button) for notes, and injects a visually hidden `<h1>` if a note lacks an explicit heading. ([src/pages/[section]/[...slug].astroR239-R275](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148R239-R275), [src/pages/[section]/[...slug].astroL297-R337](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148L297-R337), [src/pages/[section]/[...slug].astroR378-R401](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148R378-R401), [src/pages/[section]/[...slug].astroL366-R426](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148L366-R426), [src/pages/[section]/[...slug].astroR440-R448](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148R440-R448))
* Improved excerpt and title resolution logic for notes and articles, including new helpers for humanizing slugs and extracting plain text summaries. [[1]](diffhunk://#diff-e7f1892d21750099c34679deced720c8a66b32815da21e78af8b87c9d60138fbR96-R138) [[2]](diffhunk://#diff-e7f1892d21750099c34679deced720c8a66b32815da21e78af8b87c9d60138fbL110-R150) [src/pages/[section]/[...slug].astroR239-R275](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148R239-R275))

**Metadata and SEO Enhancements**

* Refined Open Graph and meta tag handling by introducing an `ogTitle` prop and improved description resolution in `Layout.astro`. [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R11) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R35) [[3]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L125-R127)
* Improved navigation highlighting and menu logic for the blog section.

**Schema and Type Updates**

* Updated article and notes types to allow optional titles and bodies, improving flexibility for note entries.

**Content Additions**

* Added an example note entry in `content/notes/standard-site.mdx` to demonstrate the new notes section.