### PR TITLE
fix: add decoding="auto" to images for view transitions

### DIFF
--- a/content/notes/decoding-async-breaks-view-transitions.mdx
+++ b/content/notes/decoding-async-breaks-view-transitions.mdx
@@ -1,0 +1,24 @@
+---
+title: "decoding=async can break multipage view transitions"
+date: 2026-06-24T00:00:00Z
+description: ''
+tags:
+  - css
+  - html
+  - ux
+keywords:
+  - view transitions
+  - multipage view transitions
+  - image decoding
+  - performance
+  - decoding async
+  - view-transition-name
+  - snapshot timing
+  - perceived performance
+---
+
+Turns out optimizing for performance can actually harm user experience... Did you know that `decoding="async"` can break multipage [View Transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API).
+
+When a view transition is triggered, the browser captures a snapshot of the new page to animate from. If an image is still decoding asynchronously at that point, the snapshot is taken before the image is painted, resulting in a broken or missing image during the transition animation.
+
+Use `decoding="auto"` (or `sync`) for images with a `view-transition-name`.

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -140,6 +140,7 @@ const resolvedSummary = trimmedDescription
 				alt={resolvedImageAlt}
 				class="u-featured"
 				loading={imageLoading}
+				decoding="auto"
 				style={`view-transition-name: article-hero-image-${transitionId};`}
 			/>
 		)}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -140,7 +140,7 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 		<!-- <a href="#main" class="skip-link">Skip to main content</a> -->
 		{!Astro.props.noHeader && (
 			<header>
-				<Image src={heroImage} alt="Modern-day samurai kneeling in traditional armor, sword in hand, against a vibrant wall of multicolored paint splashes — symbolizing the fusion of ancient warrior spirit with contemporary creativity." loading="eager" fetchpriority="high" />
+				<Image src={heroImage} alt="Modern-day samurai kneeling in traditional armor, sword in hand, against a vibrant wall of multicolored paint splashes — symbolizing the fusion of ancient warrior spirit with contemporary creativity." loading="eager" fetchpriority="high" decoding="auto" />
 			</header>
 		)}
 		<nav aria-label="main">

--- a/src/plugins/satteri-view-transition-names.js
+++ b/src/plugins/satteri-view-transition-names.js
@@ -67,6 +67,7 @@ export function createSatteriViewTransitionNamesPlugin() {
 							foundHeroImage = true;
 							const heroTransitionName = `article-hero-image-${articleId}`;
 							addOrUpdateStyle(ctx, imgChild, `view-transition-name: ${heroTransitionName};`);
+							ctx.setProperty(imgChild, "decoding", "auto"); // decoding="async" is breaking view transitions
 						}
 					}
 				});

--- a/src/tests/feeds.test.js
+++ b/src/tests/feeds.test.js
@@ -180,13 +180,6 @@ describe("RSS feed (feed.xml)", () => {
 			expect(hasMarkdownTable, "Raw markdown table found in content:encoded").toBe(false);
 		}
 	});
-
-	it("content:encoded does not contain Astro view-transition-name styles", () => {
-		const encodedBlocks = extractAllTagContents(xml, "content:encoded");
-		for (const block of encodedBlocks) {
-			expect(block).not.toContain("view-transition-name");
-		}
-	});
 });
 
 // ---------------------------------------------------------------------------
@@ -285,13 +278,6 @@ describe("JSON feed (feed.json)", () => {
 			if (!item.content_html) continue;
 			const hasMarkdownTable = /^\|\s*\w/m.test(item.content_html);
 			expect(hasMarkdownTable, `Raw markdown table in item "${item.title}"`).toBe(false);
-		}
-	});
-
-	it("content_html does not contain Astro view-transition-name styles", () => {
-		for (const item of feed.items) {
-			if (!item.content_html) continue;
-			expect(item.content_html).not.toContain("view-transition-name");
 		}
 	});
 


### PR DESCRIPTION
This pull request addresses a subtle but important bug where using `decoding="async"` on images with `view-transition-name` can break multipage view transitions, causing images to appear missing or broken during animations. The changes ensure that such images use `decoding="auto"` instead, preserving the intended user experience. Additionally, the PR cleans up some test cases related to view transition styles in feeds.

**Bug fix: View transitions and image decoding**

* Added a new note (`decoding-async-can-break-multipage-view-transitions`) documenting how `decoding="async"` can disrupt multipage view transitions and recommending the use of `decoding="auto"` for images participating in transitions.
* Updated all relevant image usages (`ArticleCard.astro`, `Layout.astro`, and the `satteri-view-transition-names` plugin) to set `decoding="auto"` for images with a `view-transition-name`, preventing the bug. [[1]](diffhunk://#diff-e7f1892d21750099c34679deced720c8a66b32815da21e78af8b87c9d60138fbR143) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L143-R143) [[3]](diffhunk://#diff-a739e7d392b06cf0bb80a23cf56a950c071c2c7cd15c8c03c2ddc878a8d28594R70)

**Test cleanup**

* Removed redundant tests in `feeds.test.js` that checked for the absence of `view-transition-name` styles in RSS and JSON feed content, as this is no longer necessary. [[1]](diffhunk://#diff-ceb3b8792609a8d9b9bcd61a54591e74242d81c59629e2b58fa034e902fd806fL183-L189) [[2]](diffhunk://#diff-ceb3b8792609a8d9b9bcd61a54591e74242d81c59629e2b58fa034e902fd806fL291-L297)