### PR TITLE
feat(opengraph): enhance metadata handling for articles and profiles

### DIFF
--- a/src/components/OpenGraph.astro
+++ b/src/components/OpenGraph.astro
@@ -4,15 +4,33 @@ interface Props {
 	description: string;
 	siteName: string;
 	url?: string;
-	type?: string;
+	type?: "website" | "article" | "profile";
 	image?: any;
 	imageAlt?: string;
+	article?: {
+		publishedTime?: Date | string;
+		modifiedTime?: Date | string;
+		author?: string | string[];
+		section?: string;
+		tags?: string[];
+	};
+	profile?: {
+		firstName?: string;
+		lastName?: string;
+		username?: string;
+		gender?: string;
+	};
 }
 
-const { title, description, siteName, url, type = "website", image, imageAlt } = Astro.props;
+const { title, description, siteName, url, type = "website", image, imageAlt, article, profile } = Astro.props;
 
 const siteBaseUrl = new URL(Astro.url.origin);
 const toAbsoluteUrl = (value: string) => new URL(value, siteBaseUrl).href;
+const toIsoDate = (value?: Date | string) => {
+	if (!value) return undefined;
+	const parsed = value instanceof Date ? value : new Date(value);
+	return Number.isNaN(parsed.valueOf()) ? undefined : parsed.toISOString();
+};
 
 const fallbackOgImage = {
 	src: "/images/opengraph.png",
@@ -39,12 +57,31 @@ const resolvedOgImage = (() => {
 		src,
 		width,
 		height,
-		alt: src === fallbackOgImage.src ? fallbackOgImage.alt : alt,
+		alt: src === fallbackOgImage.src ? fallbackOgImage.alt : alt || `${title} - ${siteName}`,
 	};
 })();
 
 const ogImageUrl = toAbsoluteUrl(resolvedOgImage.src);
 const ogUrl = url ?? Astro.url.href;
+const articleAuthors = Array.isArray(article?.author)
+	? article.author
+			.map((author: string) => author?.trim())
+			.filter((author: string | undefined): author is string => Boolean(author))
+	: article?.author?.trim()
+		? [article.author.trim()]
+		: [];
+const articleTags = Array.isArray(article?.tags)
+	? article.tags
+			.map((tag: string) => tag?.trim())
+			.filter((tag: string | undefined): tag is string => Boolean(tag))
+	: [];
+const articlePublishedTime = toIsoDate(article?.publishedTime);
+const articleModifiedTime = toIsoDate(article?.modifiedTime);
+const articleSection = article?.section?.trim();
+const profileFirstName = profile?.firstName?.trim();
+const profileLastName = profile?.lastName?.trim();
+const profileUsername = profile?.username?.trim();
+const profileGender = profile?.gender?.trim();
 ---
 
 <meta property="og:title" content={title} />
@@ -56,3 +93,32 @@ const ogUrl = url ?? Astro.url.href;
 <meta property="og:image:alt" content={resolvedOgImage.alt} />
 <meta property="og:type" content={type} />
 <meta property="og:site_name" content={siteName} />
+
+{type === "article" && articlePublishedTime && (
+	<meta property="article:published_time" content={articlePublishedTime} />
+)}
+{type === "article" && articleModifiedTime && (
+	<meta property="article:modified_time" content={articleModifiedTime} />
+)}
+{type === "article" && articleSection && (
+	<meta property="article:section" content={articleSection} />
+)}
+{type === "article" && articleAuthors.map((author: string) => (
+	<meta property="article:author" content={author} />
+))}
+{type === "article" && articleTags.map((tag: string) => (
+	<meta property="article:tag" content={tag} />
+))}
+
+{type === "profile" && profileFirstName && (
+	<meta property="profile:first_name" content={profileFirstName} />
+)}
+{type === "profile" && profileLastName && (
+	<meta property="profile:last_name" content={profileLastName} />
+)}
+{type === "profile" && profileUsername && (
+	<meta property="profile:username" content={profileUsername} />
+)}
+{type === "profile" && profileGender && (
+	<meta property="profile:gender" content={profileGender} />
+)}

--- a/src/components/OpenGraph.astro
+++ b/src/components/OpenGraph.astro
@@ -4,25 +4,41 @@ interface Props {
 	description: string;
 	siteName: string;
 	url?: string;
-	type?: "website" | "article" | "profile";
 	image?: any;
 	imageAlt?: string;
-	article?: {
-		publishedTime?: Date | string;
-		modifiedTime?: Date | string;
-		author?: string | string[];
-		section?: string;
-		tags?: string[];
-	};
-	profile?: {
-		firstName?: string;
-		lastName?: string;
-		username?: string;
-		gender?: string;
-	};
 }
 
-const { title, description, siteName, url, type = "website", image, imageAlt, article, profile } = Astro.props;
+const { title: titleProp, description, siteName, url, image, imageAlt } = Astro.props;
+
+// Middleware populates ogData for content entries (blog/speaking/notes).
+// For all other pages it is undefined and values fall back to props or URL inference.
+const ogLocals = Astro.locals.ogData;
+const trimmedPathname = Astro.url.pathname.replace(/\/+$/, "") || "/";
+const type = ogLocals?.type ?? (trimmedPathname === "/about" ? "profile" : "website");
+
+// Prefer the full entry title from middleware; the prop may be SERP-truncated.
+const title = ogLocals?.title || titleProp;
+
+const article =
+	type === "article" && ogLocals
+		? {
+				publishedTime: ogLocals.publishedTime,
+				modifiedTime: ogLocals.modifiedTime,
+				author: ogLocals.author,
+				section: ogLocals.section,
+				tags: ogLocals.tags,
+			}
+		: undefined;
+
+const profile =
+	type === "profile"
+		? {
+				// Default to site owner identity; can be overridden via ogData locals if needed.
+				firstName: ogLocals?.firstName ?? "Michaël",
+				lastName: ogLocals?.lastName ?? "Vanderheyden",
+				username: ogLocals?.username ?? "th3s4mur41",
+			}
+		: undefined;
 
 const siteBaseUrl = new URL(Astro.url.origin);
 const toAbsoluteUrl = (value: string) => new URL(value, siteBaseUrl).href;
@@ -81,7 +97,6 @@ const articleSection = article?.section?.trim();
 const profileFirstName = profile?.firstName?.trim();
 const profileLastName = profile?.lastName?.trim();
 const profileUsername = profile?.username?.trim();
-const profileGender = profile?.gender?.trim();
 ---
 
 <meta property="og:title" content={title} />
@@ -118,7 +133,4 @@ const profileGender = profile?.gender?.trim();
 )}
 {type === "profile" && profileUsername && (
 	<meta property="profile:username" content={profileUsername} />
-)}
-{type === "profile" && profileGender && (
-	<meta property="profile:gender" content={profileGender} />
 )}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,20 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+declare namespace App {
+	interface Locals {
+		/** Open Graph metadata derived from the current content entry, set by middleware. */
+		ogData?: {
+			type: "article" | "profile";
+			title?: string;
+			publishedTime?: Date;
+			modifiedTime?: Date;
+			author?: string;
+			section?: string;
+			tags?: string[];
+			firstName?: string;
+			lastName?: string;
+			username?: string;
+		};
+	}
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,21 +8,6 @@ import styles from "../index.css?url";
 
 interface Props {
 	title?: string;
-	ogTitle?: string;
-	ogType?: "website" | "article" | "profile";
-	ogArticle?: {
-		publishedTime?: Date | string;
-		modifiedTime?: Date | string;
-		author?: string | string[];
-		section?: string;
-		tags?: string[];
-	};
-	ogProfile?: {
-		firstName?: string;
-		lastName?: string;
-		username?: string;
-		gender?: string;
-	};
 	heading?: string;
 	showHeading?: boolean;
 	tagline?: string;
@@ -46,7 +31,7 @@ const showHeading = Astro.props.showHeading ?? true;
 const pageTitle = Astro.props.tagline
 	? `${siteName} | ${Astro.props.tagline}`
 	: title ? `${title} | ${siteName}` : `${siteName}`;
-const ogTitle = Astro.props.ogTitle?.trim() || title || siteName;
+const ogTitle = title || siteName;
 const header = Astro.props.heading ?? title ?? siteName;
 const currentYear = new Date().getFullYear();
 const slug = Astro.url.pathname.replace(/^\/|\/$/g, "").replace(/\//g, "-") || "home";
@@ -63,19 +48,6 @@ const canonicalUrl = (() => {
 		return new URL(Astro.url.pathname, canonicalBaseUrl).toString();
 	}
 })();
-const trimmedPathname = Astro.url.pathname.replace(/\/+$/, "") || "/";
-const inferredOgType = trimmedPathname === "/about" ? "profile" : "website";
-const ogType = Astro.props.ogType ?? inferredOgType;
-const ogProfileDefaults =
-	ogType === "profile"
-		? {
-				firstName: "Michaël",
-				lastName: "Vanderheyden",
-				username: "th3s4mur41",
-			}
-		: undefined;
-const ogProfile = ogProfileDefaults ? { ...ogProfileDefaults, ...Astro.props.ogProfile } : Astro.props.ogProfile;
-
 // Default meta description (~150 chars) optimized for primary topics without truncation in SERPs
 const desc =
 	description ||
@@ -155,11 +127,8 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 			description={desc}
 			siteName={siteName}
 			url={canonicalUrl}
-			type={ogType}
 			image={image}
 			imageAlt={imageAlt}
-			article={Astro.props.ogArticle}
-			profile={ogProfile}
 		/>
 
 		<meta name="generator" content={Astro.generator} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,6 +9,20 @@ import styles from "../index.css?url";
 interface Props {
 	title?: string;
 	ogTitle?: string;
+	ogType?: "website" | "article" | "profile";
+	ogArticle?: {
+		publishedTime?: Date | string;
+		modifiedTime?: Date | string;
+		author?: string | string[];
+		section?: string;
+		tags?: string[];
+	};
+	ogProfile?: {
+		firstName?: string;
+		lastName?: string;
+		username?: string;
+		gender?: string;
+	};
 	heading?: string;
 	showHeading?: boolean;
 	tagline?: string;
@@ -49,6 +63,18 @@ const canonicalUrl = (() => {
 		return new URL(Astro.url.pathname, canonicalBaseUrl).toString();
 	}
 })();
+const trimmedPathname = Astro.url.pathname.replace(/\/+$/, "") || "/";
+const inferredOgType = trimmedPathname === "/about" ? "profile" : "website";
+const ogType = Astro.props.ogType ?? inferredOgType;
+const ogProfileDefaults =
+	ogType === "profile"
+		? {
+				firstName: "Michaël",
+				lastName: "Vanderheyden",
+				username: "th3s4mur41",
+			}
+		: undefined;
+const ogProfile = ogProfileDefaults ? { ...ogProfileDefaults, ...Astro.props.ogProfile } : Astro.props.ogProfile;
 
 // Default meta description (~150 chars) optimized for primary topics without truncation in SERPs
 const desc =
@@ -124,7 +150,17 @@ const keyWords = Array.from(new Set([...(Astro.props.keywords ?? []), ...default
 		<link rel="apple-touch-icon" href="/icons/favicon-180.png" />
 
 		<!-- Open Graph data -->
-		<OpenGraph title={ogTitle} description={desc} siteName={siteName} image={image} imageAlt={imageAlt} />
+		<OpenGraph
+			title={ogTitle}
+			description={desc}
+			siteName={siteName}
+			url={canonicalUrl}
+			type={ogType}
+			image={image}
+			imageAlt={imageAlt}
+			article={Astro.props.ogArticle}
+			profile={ogProfile}
+		/>
 
 		<meta name="generator" content={Astro.generator} />
 		<link rel="sitemap" href="/sitemap-index.xml" />

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,59 @@
+import { getCollection } from "astro:content";
+import { defineMiddleware } from "astro:middleware";
+import { normalizeEntryId } from "./utils/contentSeries";
+
+type CollectionsCache = {
+	blog: Awaited<ReturnType<typeof getCollection<"blog">>>;
+	speaking: Awaited<ReturnType<typeof getCollection<"speaking">>>;
+	notes: Awaited<ReturnType<typeof getCollection<"notes">>>;
+};
+
+// Populated once per build; avoids redundant collection fetches across static pages.
+let collectionsCache: CollectionsCache | null = null;
+
+async function getCollections(): Promise<CollectionsCache> {
+	if (collectionsCache) return collectionsCache;
+	const [blog, speaking, notes] = await Promise.all([
+		getCollection("blog"),
+		getCollection("speaking"),
+		getCollection("notes"),
+	]);
+	collectionsCache = { blog, speaking, notes };
+	return collectionsCache;
+}
+
+export const onRequest = defineMiddleware(async (context, next) => {
+	const { pathname } = context.url;
+	// Only run for content section URLs; everything else gets no ogData and falls back to layout defaults.
+	const match = pathname.match(/^\/(blog|speaking|notes)\//);
+
+	if (match) {
+		const section = match[1] as keyof CollectionsCache;
+		// Strip leading section prefix and trailing slash to get the normalised entry slug.
+		const slug = pathname.replace(`/${section}/`, "").replace(/\/$/, "");
+
+		try {
+			const collections = await getCollections();
+			const entries = collections[section];
+			const entry = entries.find((e) => normalizeEntryId(e.id) === slug);
+
+			if (entry?.data) {
+				const d = entry.data as Record<string, unknown>;
+				context.locals.ogData = {
+					type: "article",
+					// Full untruncated title; OpenGraph prefers this over the `<title>`-optimised prop.
+					title: typeof d.title === "string" ? d.title.trim() : undefined,
+					publishedTime: d.date instanceof Date ? d.date : undefined,
+					modifiedTime: d.updated instanceof Date ? d.updated : undefined,
+					author: `${context.url.origin}/about/`,
+					section: `${section.charAt(0).toUpperCase()}${section.slice(1)}`,
+					tags: Array.isArray(d.tags) ? (d.tags as string[]) : undefined,
+				};
+			}
+		} catch {
+			// Non-fatal: OG data falls back to layout defaults.
+		}
+	}
+
+	return next();
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,16 @@ type CollectionsCache = {
 let collectionsCache: CollectionsCache | null = null;
 
 async function getCollections(): Promise<CollectionsCache> {
+	// In dev, avoid long-lived caching so HMR/content edits are reflected without restarting.
+	if (import.meta.env.DEV) {
+		const [blog, speaking, notes] = await Promise.all([
+			getCollection("blog"),
+			getCollection("speaking"),
+			getCollection("notes"),
+		]);
+		return { blog, speaking, notes };
+	}
+
 	if (collectionsCache) return collectionsCache;
 	const [blog, speaking, notes] = await Promise.all([
 		getCollection("blog"),

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -271,16 +271,6 @@ const resolvedDescription = pageEntry?.data.description?.trim()
 const translations = pageEntry?.data.translations?.map((t: any) => ({ language: t.language, url: t.url })) ?? undefined;
 const articleEyebrowText = !isSeriesPage && section === "blog" && series ? series.title : article?.data.eyebrow;
 const articleEyebrowHref = !isSeriesPage && section === "blog" && series ? `/blog/${series.slug}/` : null;
-const ogArticleMetadata =
-	!isSeriesPage && article
-		? {
-				publishedTime: article.data.date,
-				modifiedTime: article.data.updated,
-				author: `${Astro.url.origin}/about/`,
-				section: section.charAt(0).toUpperCase() + section.slice(1),
-				tags: article.data.tags,
-			}
-		: undefined;
 const siteStandardPublicationUri = SITE_CONFIG.atproto?.publicationUri;
 const siteStandardDocumentId =
 	!isSeriesPage && article ? (section === "blog" ? article.id : `${section}/${article.id}`) : undefined;
@@ -323,9 +313,6 @@ void [
 
 <Layout
   title={truncatedTitle}
-	ogTitle={trimmedEntryTitle || pageTitle}
-	ogType={!isSeriesPage && article ? "article" : "website"}
-	ogArticle={ogArticleMetadata}
 	showHeading={false}
   image={img}
 	imageAlt={pageEntry?.data.imageAlt}

--- a/src/pages/[section]/[...slug].astro
+++ b/src/pages/[section]/[...slug].astro
@@ -271,6 +271,16 @@ const resolvedDescription = pageEntry?.data.description?.trim()
 const translations = pageEntry?.data.translations?.map((t: any) => ({ language: t.language, url: t.url })) ?? undefined;
 const articleEyebrowText = !isSeriesPage && section === "blog" && series ? series.title : article?.data.eyebrow;
 const articleEyebrowHref = !isSeriesPage && section === "blog" && series ? `/blog/${series.slug}/` : null;
+const ogArticleMetadata =
+	!isSeriesPage && article
+		? {
+				publishedTime: article.data.date,
+				modifiedTime: article.data.updated,
+				author: `${Astro.url.origin}/about/`,
+				section: section.charAt(0).toUpperCase() + section.slice(1),
+				tags: article.data.tags,
+			}
+		: undefined;
 const siteStandardPublicationUri = SITE_CONFIG.atproto?.publicationUri;
 const siteStandardDocumentId =
 	!isSeriesPage && article ? (section === "blog" ? article.id : `${section}/${article.id}`) : undefined;
@@ -314,6 +324,8 @@ void [
 <Layout
   title={truncatedTitle}
 	ogTitle={trimmedEntryTitle || pageTitle}
+	ogType={!isSeriesPage && article ? "article" : "website"}
+	ogArticle={ogArticleMetadata}
 	showHeading={false}
   image={img}
 	imageAlt={pageEntry?.data.imageAlt}


### PR DESCRIPTION
This pull request refactors and enhances how Open Graph (OG) metadata is handled across the site, especially for content entries like blog posts, speaking pages, and notes. It introduces middleware to automatically populate OG metadata from content collections, adds support for richer OG types (like `article` and `profile`), and simplifies prop usage in layout and OG components. These changes ensure more accurate and detailed OG tags for content, improving link previews and SEO.

**Open Graph metadata improvements:**

* Added middleware (`src/middleware.ts`) to automatically populate `ogData` in `Astro.locals` for blog, speaking, and notes entries, including full title, publication/modification dates, author, section, and tags.
* Updated `OpenGraph.astro` to use `ogData` when available, inferring the correct `og:type` (`article`, `profile`, or `website`) and supporting additional OG meta tags for articles and profiles (e.g., `article:published_time`, `profile:first_name`). [[1]](diffhunk://#diff-512ed0c9e9fb50b81f9a207bef09b9e0c9a0f6c63cc32cabfa16c6fb5a476fa2L7-R49) [[2]](diffhunk://#diff-512ed0c9e9fb50b81f9a207bef09b9e0c9a0f6c63cc32cabfa16c6fb5a476fa2L42-R99) [[3]](diffhunk://#diff-512ed0c9e9fb50b81f9a207bef09b9e0c9a0f6c63cc32cabfa16c6fb5a476fa2R111-R136)
* Improved OG image handling to provide better alt text and absolute URLs.

**Layout and prop simplification:**

* Removed the `ogTitle` prop from `Layout.astro` and related usages, as the OG title is now derived automatically. [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L11) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L35-R34) [src/pages/[section]/[...slug].astroL316](diffhunk://#diff-6e138ed7fd696c5cc974e014297086d7962a8ed256a08d5f91a544f7a2a1d148L316))
* Ensured `OpenGraph` always receives the canonical URL and consistent props from the layout.

These changes centralize OG metadata logic, reduce duplication, and ensure richer, more accurate previews for content shared on social media and other platforms.