### PR TITLE
fix: properly handle svg images in content

### DIFF
--- a/src/components/Image.astro
+++ b/src/components/Image.astro
@@ -6,7 +6,7 @@ import { getImage } from "astro:assets";
 import type { ImageMetadata } from "astro";
 
 interface Props {
-	src: ImageMetadata | string | URL | { src?: string; default?: string };
+	src: ImageMetadata | string | URL | { src?: ImageMetadata | string | URL; default?: ImageMetadata | string | URL };
 	alt: string;
 	width?: number | string;
 	height?: number | string;
@@ -52,8 +52,9 @@ function isImageMetadata(value: Props["src"]): value is ImageMetadata {
 function sourceToString(value: unknown): string {
 	if (typeof value === "string") return value;
 	if (value instanceof URL) return value.toString();
-	if (typeof value === "object" && value !== null && "href" in value && typeof value.href === "string") {
-		return value.href;
+	if (typeof value === "object" && value !== null) {
+		if ("src" in value && typeof (value as any).src === "string") return (value as any).src;
+		if ("href" in value && typeof (value as any).href === "string") return (value as any).href;
 	}
 	return "";
 }

--- a/src/components/Image.astro
+++ b/src/components/Image.astro
@@ -6,7 +6,7 @@ import { getImage } from "astro:assets";
 import type { ImageMetadata } from "astro";
 
 interface Props {
-	src: ImageMetadata | string;
+	src: ImageMetadata | string | URL | { src?: string; default?: string };
 	alt: string;
 	width?: number | string;
 	height?: number | string;
@@ -44,12 +44,39 @@ const {
 	title,
 } = Astro.props;
 
-function isImageMetadata(value: ImageMetadata | string): value is ImageMetadata {
-	return typeof value === "object" && value !== null && "src" in value && "width" in value && "height" in value;
+function isImageMetadata(value: Props["src"]): value is ImageMetadata {
+	const isObjectLike = (typeof value === "object" && value !== null) || typeof value === "function";
+	return isObjectLike && "src" in value && "width" in value && "height" in value;
+}
+
+function sourceToString(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (value instanceof URL) return value.toString();
+	if (typeof value === "object" && value !== null && "href" in value && typeof value.href === "string") {
+		return value.href;
+	}
+	return "";
+}
+
+function resolveRawSource(value: Props["src"]): string {
+	const direct = sourceToString(value);
+	if (direct) return direct;
+
+	if ((typeof value === "object" && value !== null) || typeof value === "function") {
+		if ("src" in value) {
+			const nestedSrc = sourceToString(value.src);
+			if (nestedSrc) return nestedSrc;
+		}
+		if ("default" in value) {
+			const nestedDefault = sourceToString(value.default);
+			if (nestedDefault) return nestedDefault;
+		}
+	}
+	return "";
 }
 
 const imageMetadata = isImageMetadata(src) ? src : null;
-const stringSrc = typeof src === "string" ? src : null;
+const rawSource = resolveRawSource(src);
 
 // Get original image size directly from metadata to avoid extra pipeline run
 const originalWidth = imageMetadata?.width;
@@ -121,11 +148,11 @@ if (!isSvg && imageMetadata && originalWidth) {
 	}
 }
 
-const rawSrc = imageMetadata?.src ?? stringSrc ?? "";
+const rawSrc = (imageMetadata ? resolveRawSource(imageMetadata.src) : "") || rawSource;
 
-if (stringSrc && !rawImageWidth && !rawImageHeight && import.meta.env.DEV) {
+if (rawSource && !rawImageWidth && !rawImageHeight && import.meta.env.DEV) {
 	console.warn(
-		`[Image] String source rendered without width/height for "${stringSrc}" in "${imageContext}". Consider passing width and height to prevent layout shift.`,
+		`[Image] Source rendered without width/height for "${rawSource}" in "${imageContext}". Consider passing width and height to prevent layout shift.`,
 	);
 }
 ---

--- a/src/styles/pages/blog.css
+++ b/src/styles/pages/blog.css
@@ -121,6 +121,7 @@ body:is([class^="blog-"]:where(:not([class^="blog-tags-"])), [class^="speaking-"
 		}
 		& p:has(:is(img, picture):only-child) {
 			text-align: center;
+			justify-items: center;
 		}
 		& > footer {
 			display: flex;


### PR DESCRIPTION
This pull request updates the `Image.astro` component to support a wider range of image source types and improves how image sources are resolved and handled. It also includes a minor style adjustment for blog image alignment. The main changes are grouped below:

**Image Source Handling Improvements:**

* The `src` prop for `Image.astro` now accepts `ImageMetadata`, `string`, `URL`, or objects with optional `src` or `default` properties, making the component more flexible for various image source formats.
* Added utility functions `sourceToString` and `resolveRawSource` to robustly extract a string URL from the extended set of possible `src` values, including nested or default properties.
* Updated the logic for determining the raw image source (`rawSrc`) and improved the developer warning message to use the resolved source, ensuring accurate feedback when width and height are missing.

**Styling Adjustment:**

* Centered images in blog posts by adding `justify-items: center` to the relevant CSS rule, improving the visual alignment of images.